### PR TITLE
fix: Harden Pow DoS, cache dir security, and Poseidon allocations

### DIFF
--- a/cli/src/commands/circuit.rs
+++ b/cli/src/commands/circuit.rs
@@ -151,9 +151,7 @@ fn run_r1cs_pipeline(
 
     // Generate Solidity verifier if requested
     if let Some(sol_path) = solidity_path {
-        let cache_dir = std::env::var("HOME")
-            .map(|h| std::path::PathBuf::from(h).join(".achronyme").join("cache"))
-            .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/achronyme/cache"));
+        let cache_dir = crate::cache_dir();
 
         let vk = crate::groth16::setup_vk_only(&compiler.cs, &cache_dir)
             .map_err(|e| anyhow::anyhow!("Groth16 setup failed: {e}"))?;
@@ -193,9 +191,7 @@ fn run_plonkish_pipeline(program: &ir::IrProgram, inputs: Option<&str>, prove: b
         eprintln!("plonkish verification: OK");
 
         if prove {
-            let cache_dir = std::env::var("HOME")
-                .map(|h| std::path::PathBuf::from(h).join(".achronyme").join("cache"))
-                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp/achronyme/cache"));
+            let cache_dir = crate::cache_dir();
 
             let result = crate::halo2_proof::generate_plonkish_proof(compiler, &cache_dir)
                 .map_err(|e| anyhow::anyhow!("Plonkish proof generation error: {e}"))?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,3 +4,17 @@ pub mod halo2_proof;
 pub mod prove_handler;
 pub mod repl;
 pub mod solidity;
+
+/// Return the cache directory for Achronyme key material.
+///
+/// Prefers `$HOME/.achronyme/cache`.  Falls back to a user-scoped
+/// temporary directory (`$TMPDIR/achronyme-cache`) rather than the
+/// world-writable `/tmp`.
+pub fn cache_dir() -> std::path::PathBuf {
+    if let Ok(home) = std::env::var("HOME") {
+        return std::path::PathBuf::from(home)
+            .join(".achronyme")
+            .join("cache");
+    }
+    std::env::temp_dir().join("achronyme-cache")
+}

--- a/cli/src/prove_handler.rs
+++ b/cli/src/prove_handler.rs
@@ -24,9 +24,7 @@ pub struct DefaultProveHandler {
 
 impl DefaultProveHandler {
     pub fn new(backend: ProveBackend) -> Self {
-        let cache_dir = std::env::var("HOME")
-            .map(|h| PathBuf::from(h).join(".achronyme").join("cache"))
-            .unwrap_or_else(|_| PathBuf::from("/tmp/achronyme/cache"));
+        let cache_dir = crate::cache_dir();
         Self { cache_dir, backend }
     }
 }

--- a/constraints/src/poseidon.rs
+++ b/constraints/src/poseidon.rs
@@ -540,8 +540,9 @@ pub fn poseidon_permutation(params: &PoseidonParams, state: &mut [FieldElement])
             state[0] = sbox(state[0]);
         }
 
-        // 3. MDS matrix multiplication
-        let old = state.to_vec();
+        // 3. MDS matrix multiplication (stack copy avoids heap allocation)
+        let mut old = [FieldElement::ZERO; 3];
+        old[..params.t].copy_from_slice(&state[..params.t]);
         for i in 0..params.t {
             state[i] = FieldElement::ZERO;
             for j in 0..params.t {
@@ -560,7 +561,7 @@ pub fn poseidon_hash(
     left: FieldElement,
     right: FieldElement,
 ) -> FieldElement {
-    let mut state = vec![FieldElement::ZERO; params.t]; // capacity = 0
+    let mut state = [FieldElement::ZERO; 3]; // capacity = 0
     state[1] = left;
     state[2] = right;
     poseidon_permutation(params, &mut state);
@@ -572,7 +573,7 @@ pub fn poseidon_hash(
 /// State: [capacity=0, input, 0]
 /// Output: state[0] after permutation (circomlibjs convention)
 pub fn poseidon_hash_single(params: &PoseidonParams, input: FieldElement) -> FieldElement {
-    let mut state = vec![FieldElement::ZERO; params.t];
+    let mut state = [FieldElement::ZERO; 3];
     state[1] = input;
     poseidon_permutation(params, &mut state);
     state[0]


### PR DESCRIPTION
## Summary
- Cap VM integer `Pow` loop at 63 iterations; larger exponents promote to field pow (O(log n)) preventing DoS via huge exponents
- Extract `cache_dir()` helper using `$TMPDIR` instead of world-writable `/tmp` for crypto key material fallback
- Replace Poseidon hot-loop heap allocations with stack arrays, eliminating ~67 allocations per hash

## Test plan
- [x] `cargo test --workspace` — all 700+ tests pass
- [x] `cargo clippy --workspace` — no warnings