### PR TITLE
fix: Use pnpm 10 in docs workflow to match lockfile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Install dependencies
         run: cd docs && pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Change pnpm version from 9 to 10 in docs deploy workflow
- The lockfile was generated with pnpm 10.28, causing `--frozen-lockfile` to fail with pnpm 9

## Test plan
- [ ] Verify `pnpm install --frozen-lockfile` succeeds in CI