### PR TITLE
fix: Include workflow file in docs deploy path filter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Install dependencies
         run: cd docs && pnpm install --frozen-lockfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
-    paths: ['docs/**']
+    paths: ['docs/**', '.github/workflows/docs.yml']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/docs.yml` to the path filter so changes to the workflow itself trigger a deploy

## Test plan
- [x] Path filter now covers both `docs/**` and the workflow file