### PR TITLE
docs: Add documentation site with circuit programming content

### DIFF
--- a/docs/src/content/docs/circuits/builtins.mdx
+++ b/docs/src/content/docs/circuits/builtins.mdx
@@ -1,6 +1,132 @@
 ---
-title: "Circuit Builtins"
-description: "Built-in functions for circuit programming."
+title: "Builtins"
+description: "Built-in functions available in circuits."
 ---
 
-Content coming soon.
+Circuits provide built-in functions for assertions, hashing, conditional selection, and range checking. Each builtin compiles to a fixed number of constraints.
+
+## Quick Reference
+
+| Builtin | Constraints (R1CS) | Purpose |
+|---------|-------------------|---------|
+| `assert_eq(a, b)` | 1 | Enforce equality |
+| `assert(expr)` | 2 | Enforce boolean expression is true |
+| `poseidon(a, b)` | 361 | Poseidon 2-to-1 hash |
+| `poseidon_many(a, b, c, ...)` | (N−1) × 361 | Left-fold Poseidon hash |
+| `mux(cond, a, b)` | 2 | Conditional selection |
+| `range_check(x, bits)` | bits + 1 | Value fits in N bits |
+| `merkle_verify(root, leaf, path, indices)` | depth × ~363 | Merkle membership proof |
+| `len(arr)` | 0 | Compile-time array length |
+
+## assert_eq
+
+Enforces that two expressions are equal. Costs 1 constraint.
+
+```
+public out
+witness a
+witness b
+
+let product = a * b
+assert_eq(product, out)
+```
+
+This is the most common builtin — use it to bind computed values to public outputs.
+
+## assert
+
+Enforces that a boolean expression is true. Costs 2 constraints (one for boolean enforcement, one to enforce the value equals 1).
+
+```
+witness x
+witness y
+
+assert(x < y)
+```
+
+Unlike `assert_eq`, this works with any expression that evaluates to 0 or 1.
+
+## poseidon
+
+Computes a Poseidon 2-to-1 hash. Costs 361 constraints (360 for the permutation rounds + 1 for the capacity wire). The output is compatible with circomlibjs.
+
+```
+public expected
+witness a
+witness b
+
+let h = poseidon(a, b)
+assert_eq(h, expected)
+```
+
+## poseidon_many
+
+Hashes an arbitrary number of values by left-folding `poseidon`. Three arguments cost 2 × 361 = 722 constraints, four arguments cost 3 × 361 = 1083, and so on.
+
+```
+public expected
+witness a
+witness b
+witness c
+
+// poseidon_many(a, b, c) == poseidon(poseidon(a, b), c)
+let h = poseidon_many(a, b, c)
+assert_eq(h, expected)
+```
+
+## mux
+
+Conditional selection: returns `a` when `cond` is 1, `b` when `cond` is 0. Costs 2 constraints (one boolean enforcement for `cond`, one selection constraint).
+
+```
+public out
+witness cond
+witness a
+witness b
+
+let selected = mux(cond, a, b)
+assert_eq(selected, out)
+```
+
+Both `a` and `b` are always evaluated — there is no short-circuit behavior.
+
+## range_check
+
+Proves that a value fits within a given number of bits. In R1CS, this costs `bits + 1` constraints (boolean decomposition). In Plonkish, it costs 1 lookup.
+
+```
+witness x
+witness y
+
+// x fits in 8 bits (0..255)
+range_check(x, 8)
+
+// y fits in 16 bits (0..65535)
+range_check(y, 16)
+```
+
+## merkle_verify
+
+Verifies a Merkle membership proof. Takes a root, a leaf, an array of sibling hashes (the path), and an array of direction indices (0 = left, 1 = right). The proof is unrolled at the IR level — each level costs roughly 363 constraints (one Poseidon hash + a mux).
+
+```
+public root
+witness leaf
+witness path[1]
+witness indices[1]
+
+merkle_verify(root, leaf, path, indices)
+```
+
+The `path` and `indices` arrays must have the same length, which determines the tree depth.
+
+## len
+
+Returns the compile-time length of an array. Costs 0 constraints — the value is resolved during compilation.
+
+```
+witness vals[3]
+
+let n = len(vals)
+assert_eq(n, 3)
+```

--- a/docs/src/content/docs/circuits/control-flow.mdx
+++ b/docs/src/content/docs/circuits/control-flow.mdx
@@ -1,6 +1,98 @@
 ---
 title: "Control Flow in Circuits"
-description: "How control flow compiles to constraints."
+description: "for loops, if/else, let bindings, and rejected constructs."
 ---
 
-Content coming soon.
+Circuits support a subset of Achronyme's control flow. Every construct must resolve at compile time — the compiler needs to know the exact structure of the constraint system before any inputs are provided.
+
+## for Loops
+
+`for` loops are statically unrolled — the compiler expands every iteration into separate constraints. Two forms are supported.
+
+**Range form** — iterate over `start..end`:
+
+```
+public out
+witness a
+witness b
+
+let product = a * b
+assert_eq(product, out)
+
+let sum = a + b
+assert_eq(sum, a + b)
+```
+
+**Array form** — iterate over a declared array:
+
+```
+public expected_sum
+witness vals[3]
+
+let acc = vals[0]
+let acc = acc + vals[1]
+let acc = acc + vals[2]
+assert_eq(acc, expected_sum)
+```
+
+The constraint cost of a loop equals the number of iterations multiplied by the cost of the body.
+
+### Nested Loops
+
+Nested `for` loops are supported. The total iteration count is the product of all loop bounds:
+
+```
+witness matrix[9]
+
+for i in 0..3 {
+    for j in 0..3 {
+        range_check(matrix[i * 3 + j], 8)
+    }
+}
+```
+
+This unrolls to 9 iterations, each with a `range_check` (9 constraints in R1CS, 9 lookups in Plonkish).
+
+## if/else as mux
+
+In circuits, `if/else` compiles to a **mux** (multiplexer) — both branches are always evaluated, and the condition selects which result to use. This costs 2 constraints (one boolean enforcement for the condition, one selection constraint).
+
+```
+witness cond
+witness a
+witness b
+
+let result = if cond { a } else { b }
+```
+
+This is equivalent to `mux(cond, a, b)`. There is no short-circuit evaluation — both `a` and `b` are computed regardless of `cond`.
+
+An `if` without `else` is not supported in circuits because both branches must produce a value for the mux.
+
+## let Bindings
+
+`let` bindings create aliases — they do not emit constraints. A `let` just gives a name to an existing linear combination.
+
+```
+witness a
+witness b
+
+let sum = a + b        // 0 constraints — just an alias
+let doubled = sum + sum // 0 constraints — still a linear combination
+```
+
+Bindings only cost constraints when they involve operations that require multiplication gates (e.g., `let product = a * b` costs 1 constraint for the multiplication, not for the `let`).
+
+## Rejected Constructs
+
+These constructs are rejected at compile time with clear error messages:
+
+| Construct | Error | Reason |
+|-----------|-------|--------|
+| `while` | `WhileInCircuit` | Iteration count unknown at compile time |
+| `forever` | `ForeverInCircuit` | Same — unbounded loops can't be unrolled |
+| `break` | `BreakInCircuit` | Dynamic exit not representable in constraints |
+| `continue` | `ContinueInCircuit` | Dynamic skip not representable in constraints |
+| `print()` | — | Side effect with no circuit equivalent |
+
+Circuits require a fixed, deterministic constraint structure. Any construct that depends on runtime values to determine control flow is incompatible with this model.

--- a/docs/src/content/docs/circuits/declarations.mdx
+++ b/docs/src/content/docs/circuits/declarations.mdx
@@ -3,4 +3,89 @@ title: "Declarations"
 description: "Public and witness declarations in circuits."
 ---
 
-Content coming soon.
+Every circuit needs explicit input declarations. These tell the compiler which variables are **public** (visible to the verifier) and which are **witness** (known only to the prover).
+
+## Scalar Declarations
+
+Declare one variable at a time:
+
+```
+public output
+witness secret
+```
+
+Or multiple on one line, separated by commas:
+
+```
+public x, y
+witness a, b, c
+```
+
+Public inputs become part of the proof's public statement — anyone verifying the proof can see their values. Witness inputs remain private to the prover.
+
+## Array Declarations
+
+Declare a fixed-size array of inputs with bracket syntax:
+
+```
+witness path[3]
+witness indices[3]
+```
+
+This creates three indexed variables (`path_0`, `path_1`, `path_2`) that you access with standard indexing. Array declarations work for both public and witness inputs:
+
+```
+public commitments[4]
+witness secrets[4]
+```
+
+## Using Declared Inputs
+
+Once declared, inputs are ordinary variables. Use them in expressions, pass them to builtins, and index into arrays:
+
+```
+public output
+witness a
+witness b
+
+let product = a * b
+assert_eq(product, output)
+
+let sum = a + b
+assert_eq(sum, a + b)
+```
+
+Array elements are accessed by index:
+
+```
+public expected_sum
+witness vals[3]
+
+let acc = vals[0]
+let acc = acc + vals[1]
+let acc = acc + vals[2]
+assert_eq(acc, expected_sum)
+```
+
+## CLI Alternative
+
+Instead of in-source declarations, you can declare inputs with CLI flags:
+
+```bash
+ach circuit program.ach --public output --witness a,b --inputs "a=3,b=5,output=15"
+```
+
+The `--public` and `--witness` flags accept comma-separated variable names. If the source file already contains `public`/`witness` declarations, omit the flags — the compiler picks them up automatically.
+
+Array inputs are passed with indexed names:
+
+```bash
+ach circuit merkle.ach --inputs "root=123,leaf=42,path_0=99,path_1=77,indices_0=0,indices_1=1"
+```
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| `DuplicateInput` | Same name declared as both `public` and `witness`, or declared twice |
+| `UndeclaredVariable` | Using a variable that was never declared as `public` or `witness` |

--- a/docs/src/content/docs/circuits/functions.mdx
+++ b/docs/src/content/docs/circuits/functions.mdx
@@ -1,6 +1,83 @@
 ---
 title: "Functions in Circuits"
-description: "How functions work in circuit mode."
+description: "How functions work inside circuit compilation."
 ---
 
-Content coming soon.
+Functions in circuits use the same `fn` syntax as regular Achronyme code, but they behave differently under the hood — every call is inlined.
+
+## Syntax
+
+Define functions the same way as in regular mode:
+
+```
+fn double(x) {
+    x + x
+}
+```
+
+Call them as usual:
+
+```
+witness vals[3]
+
+fn double(x) { x + x }
+assert_eq(double(vals[0]), vals[0] + vals[0])
+```
+
+## Inlining
+
+There is no function call stack in circuits. Every call site expands the function body with the arguments substituted in. If you call a function 5 times, its body is compiled 5 times.
+
+```
+fn square(x) { x * x }
+
+// Each call inlines independently — 1 constraint each
+let a = square(vals[0])
+let b = square(vals[1])
+let c = square(vals[2])
+```
+
+This means functions are a convenience for code organization, not a mechanism for reducing constraint count.
+
+## Constraint Cost
+
+The cost of a function call equals the sum of its body's constraints. A function with two multiplications costs 2 constraints per call.
+
+```
+fn dot(a0, a1, b0, b1) {
+    a0 * b0 + a1 * b1      // 2 constraints (two variable multiplications)
+}
+```
+
+Calling `dot` three times produces 6 constraints.
+
+## Restrictions
+
+| Restriction | Error | Reason |
+|-------------|-------|--------|
+| No recursion | `RecursiveFunction` | Functions are inlined — recursion would loop forever |
+| No closures | — | No runtime environment to capture |
+| No higher-order functions | — | Cannot pass functions as circuit values |
+| No anonymous functions | — | Only named `fn` definitions are supported |
+
+Functions in circuits are purely a compile-time mechanism. They cannot capture variables from outer scopes (except declared inputs), cannot be passed as values, and cannot call themselves.
+
+## Example
+
+A complete circuit using a helper function:
+
+```
+public expected_sum
+witness vals[3]
+
+let acc = vals[0]
+let acc = acc + vals[1]
+let acc = acc + vals[2]
+assert_eq(acc, expected_sum)
+
+let n = len(vals)
+assert_eq(n, 3)
+
+fn double(x) { x + x }
+assert_eq(double(vals[0]), vals[0] + vals[0])
+```

--- a/docs/src/content/docs/circuits/operators-and-costs.mdx
+++ b/docs/src/content/docs/circuits/operators-and-costs.mdx
@@ -1,6 +1,86 @@
 ---
 title: "Operators & Costs"
-description: "Operator constraint costs in R1CS and Plonkish."
+description: "Arithmetic, comparison, and logical operators with their constraint costs."
 ---
 
-Content coming soon.
+Every operation in a circuit compiles to zero or more constraints. Understanding costs helps you write efficient circuits — fewer constraints mean faster proof generation and smaller proofs.
+
+## Arithmetic Operators
+
+| Operator | Example | Constraints | Notes |
+|----------|---------|-------------|-------|
+| `+` | `a + b` | 0 | Linear combination |
+| `-` | `a - b` | 0 | Linear combination |
+| `*` (by constant) | `a * 3` | 0 | Scalar multiplication of LC |
+| `*` (two variables) | `a * b` | 1 | Multiplication gate |
+| `/` (by constant) | `a / 3` | 0 | Multiply by inverse |
+| `/` (two variables) | `a / b` | 2 | Inverse + multiplication |
+| `^` (exponentiation) | `x ^ n` | O(log n) | Square-and-multiply |
+| `-` (negation) | `-a` | 0 | Negate LC coefficients |
+
+```
+public x2
+public x3
+public x4
+witness x
+
+assert_eq(x ^ 2, x2)
+assert_eq(x ^ 3, x3)
+assert_eq(x ^ 4, x4)
+```
+
+## Comparison Operators
+
+| Operator | Example | Constraints | Notes |
+|----------|---------|-------------|-------|
+| `==` | `a == b` | 2 | IsZero gadget |
+| `!=` | `a != b` | 2 | IsZero gadget + negate |
+| `<` | `a < b` | ~760 | 253-bit decomposition + range checks |
+| `<=` | `a <= b` | ~760 | 253-bit decomposition + range checks |
+| `>` | `a > b` | ~760 | Same as `b < a` |
+| `>=` | `a >= b` | ~760 | Same as `b <= a` |
+
+Equality checks are cheap (2 constraints). Ordering comparisons are expensive (~760 constraints each) because they require bit decomposition over the BN254 field. Use them sparingly.
+
+```
+witness x
+witness y
+
+let eq = x == y
+let lt = x < y
+assert(lt)
+```
+
+## Logical Operators
+
+| Operator | Example | Constraints | Notes |
+|----------|---------|-------------|-------|
+| `&&` | `a && b` | 3 | 2 boolean enforcements + 1 multiplication |
+| `\|\|` | `a \|\| b` | 3 | 2 boolean enforcements + 1 gate |
+| `!` | `!a` | 0–1 | Free if operand is already proven boolean |
+
+```
+witness x
+witness y
+
+let both = (x < y) && (y > x)
+assert(both)
+
+let either = (x == y) || (x < y)
+assert(either)
+
+let not_eq = !(x == y)
+assert(not_eq)
+```
+
+## Why Some Operations Are Free
+
+Addition and subtraction are free because they operate on **linear combinations** — weighted sums of variables. The R1CS constraint system represents wires as linear combinations, so adding two LCs just merges their terms without creating a new constraint.
+
+Multiplication by a constant is also free — it scales all coefficients in the LC. Only multiplication of two variable expressions requires a constraint gate (`A * B = C`).
+
+## Optimization: Boolean Propagation
+
+The compiler's `bool_prop` pass tracks which variables are already proven to be boolean (0 or 1). When a value produced by `==`, `<`, or another comparison feeds into `&&`, `||`, or `!`, the redundant boolean enforcement is skipped, saving constraints.
+
+For example, `!(x == y)` costs 2 constraints for the `==` and 0 for the `!`, because the output of `==` is already known to be boolean.

--- a/docs/src/content/docs/language/arrays-and-collections.mdx
+++ b/docs/src/content/docs/language/arrays-and-collections.mdx
@@ -3,4 +3,156 @@ title: "Arrays & Collections"
 description: "Arrays, lists, and maps."
 ---
 
-Content coming soon.
+Achronyme has two built-in collection types: arrays (ordered lists) and maps (key-value dictionaries). Both are heap-allocated, mutable, and can hold any value type.
+
+## Arrays
+
+Create arrays with square brackets. Access elements by index (zero-based).
+
+```
+let arr = [10, 20, 30]
+assert(arr[0] == 10)
+assert(arr[2] == 30)
+
+let mixed = [1, "two", true, nil]
+assert(len(mixed) == 4)
+
+let nested = [[1, 2], [3, 4]]
+assert(nested[0][1] == 2)
+```
+
+Mutate arrays with index assignment, `push()`, and `pop()`:
+
+```
+mut nums = [0, 0, 0]
+nums[0] = 10
+assert(nums[0] == 10)
+
+mut items = [1, 2]
+push(items, 3)
+assert(len(items) == 3)
+
+let last = pop(items)
+assert(last == 3)
+assert(len(items) == 2)
+```
+
+## Array Builtins
+
+| Function | Description |
+|----------|-------------|
+| `len(arr)` | Number of elements |
+| `push(arr, val)` | Append to end |
+| `pop(arr)` | Remove and return last element |
+
+## Maps
+
+Create maps with curly braces. Keys can be bare identifiers or quoted strings.
+
+```
+let person = {name: "Alice", age: 30}
+assert(person.name == "Alice")
+assert(person["age"] == 30)
+
+let m = {"hello": 1, "world": 2}
+assert(m["hello"] == 1)
+```
+
+Access values with dot notation or bracket notation. Bracket notation supports dynamic keys.
+
+```
+let key = "name"
+assert(person[key] == "Alice")
+
+let nested = {a: {b: {c: 42}}}
+assert(nested.a.b.c == 42)
+```
+
+Add or update fields by assignment:
+
+```
+mut config = {}
+config.debug = true
+config["port"] = 8080
+assert(len(config) == 2)
+```
+
+## Map Builtins
+
+| Function | Description |
+|----------|-------------|
+| `len(map)` | Number of key-value pairs |
+| `keys(map)` | Array of all keys |
+
+## Iteration
+
+Use `for..in` to iterate over arrays directly or over map keys with `keys()`.
+
+```
+mut total = 0
+for x in [10, 20, 30] {
+    total = total + x
+}
+assert(total == 60)
+
+let scores = {math: 95, science: 88, english: 92}
+mut sum = 0
+for k in keys(scores) {
+    sum = sum + scores[k]
+}
+assert(sum == 275)
+```
+
+## Patterns
+
+**Dispatch table** — store functions in a map for dynamic lookup:
+
+```
+let ops = {
+    add: fn(a, b) { a + b },
+    sub: fn(a, b) { a - b },
+    mul: fn(a, b) { a * b }
+}
+assert(ops.add(10, 3) == 13)
+assert(ops["mul"](4, 5) == 20)
+```
+
+**Records** — use maps as lightweight structs:
+
+```
+fn make_point(x, y) {
+    return {x: x, y: y}
+}
+let p = make_point(3, 4)
+assert(p.x == 3)
+```
+
+**Word counting** — dynamic keys for aggregation:
+
+```
+mut counts = {}
+let words = ["apple", "banana", "apple", "cherry", "banana", "apple"]
+for w in words {
+    if counts[w] == nil {
+        counts[w] = 0
+    }
+    counts[w] = counts[w] + 1
+}
+assert(counts.apple == 3)
+assert(counts.banana == 2)
+```
+
+**Nested structures** — arrays of maps, maps of arrays:
+
+```
+let people = [
+    {name: "Alice", age: 30},
+    {name: "Bob", age: 25}
+]
+assert(people[0].name == "Alice")
+
+mut bag = {items: []}
+push(bag.items, "sword")
+push(bag.items, "shield")
+assert(len(bag.items) == 2)
+```

--- a/docs/src/content/docs/language/control-flow.mdx
+++ b/docs/src/content/docs/language/control-flow.mdx
@@ -3,4 +3,165 @@ title: "Control Flow"
 description: "if/else, while, for loops, break, and continue."
 ---
 
-Content coming soon.
+Achronyme provides standard control flow constructs. `if/else` is an expression that returns a value. Loops come in three forms: `while`, `forever`, and `for..in`.
+
+## if / else
+
+`if/else` blocks are expressions — they evaluate to the last expression in the taken branch. An `if` without `else` returns `nil` when the condition is false.
+
+```
+let x = if true { 10 } else { 20 }
+assert(x == 10)
+
+let min = if 3 < 5 { 3 } else { 5 }
+assert(min == 3)
+```
+
+Chain conditions with `else if`:
+
+```
+let grade = 85
+mut ltr = "F"
+if grade >= 90 {
+    ltr = "A"
+} else if grade >= 80 {
+    ltr = "B"
+} else if grade >= 70 {
+    ltr = "C"
+}
+assert(ltr == "B")
+```
+
+`if/else` chains are also expressions:
+
+```
+let val = if false {
+    1
+} else if true {
+    42
+} else {
+    99
+}
+assert(val == 42)
+```
+
+## while
+
+Repeats a block while the condition is true.
+
+```
+mut sum = 0
+mut i = 1
+while i <= 10 {
+    sum = sum + i
+    i = i + 1
+}
+assert(sum == 55)
+```
+
+## forever
+
+An infinite loop. Use `break` to exit.
+
+```
+mut count = 0
+forever {
+    count = count + 1
+    if count == 5 { break }
+}
+assert(count == 5)
+```
+
+## for..in
+
+Iterates over a range or a collection.
+
+**Range form** — `start..end` (exclusive upper bound):
+
+```
+mut sum = 0
+for i in 0..5 {
+    sum = sum + i
+}
+assert(sum == 10)
+```
+
+**Collection form** — iterates over arrays or `keys(map)`:
+
+```
+mut total = 0
+for x in [10, 20, 30] {
+    total = total + x
+}
+assert(total == 60)
+
+let scores = {math: 95, science: 88, english: 92}
+mut sum = 0
+for k in keys(scores) {
+    sum = sum + scores[k]
+}
+assert(sum == 275)
+```
+
+## break
+
+Exits the innermost loop immediately.
+
+```
+mut found = -1
+mut pos = 0
+let haystack = [5, 3, 8, 1, 9]
+for val in haystack {
+    if val == 8 {
+        found = pos
+        break
+    }
+    pos = pos + 1
+}
+assert(found == 2)
+```
+
+`break` only affects the innermost loop in nested structures:
+
+```
+mut outer = 0
+mut total = 0
+while outer < 3 {
+    mut inner = 0
+    forever {
+        inner = inner + 1
+        total = total + 1
+        if inner == 2 { break }
+    }
+    outer = outer + 1
+}
+assert(total == 6)
+```
+
+## continue
+
+Skips the rest of the current iteration and moves to the next one.
+
+```
+mut odds = 0
+mut k = 0
+while k < 10 {
+    k = k + 1
+    if k % 2 == 0 { continue }
+    odds = odds + 1
+}
+assert(odds == 5)
+```
+
+## Quick Reference
+
+| Construct | Syntax | Notes |
+|-----------|--------|-------|
+| if/else | `if cond { a } else { b }` | Expression — returns a value |
+| else if | `if c1 { } else if c2 { } else { }` | Chainable |
+| while | `while cond { body }` | Standard loop |
+| forever | `forever { body }` | Must `break` to exit |
+| for..in range | `for i in 0..n { body }` | Exclusive upper bound |
+| for..in collection | `for x in arr { body }` | Arrays, `keys(map)` |
+| break | `break` | Exits innermost loop |
+| continue | `continue` | Skips to next iteration |

--- a/docs/src/content/docs/language/functions-and-closures.mdx
+++ b/docs/src/content/docs/language/functions-and-closures.mdx
@@ -3,4 +3,167 @@ title: "Functions & Closures"
 description: "Function definitions, closures, and recursion."
 ---
 
-Content coming soon.
+Functions are first-class values in Achronyme. They can be assigned to variables, passed as arguments, and returned from other functions.
+
+## Function Declarations
+
+Define named functions with `fn name(params) { body }`.
+
+```
+fn add(a, b) {
+    return a + b
+}
+assert(add(3, 4) == 7)
+
+fn greet() {
+    return "hello"
+}
+assert(greet() == "hello")
+```
+
+## Anonymous Functions
+
+Create unnamed functions with `fn(params) { body }` and assign them to variables.
+
+```
+let double = fn(x) { x * 2 }
+assert(double(5) == 10)
+
+let mul = fn(a, b) { return a * b }
+assert(mul(3, 7) == 21)
+```
+
+## Return Values
+
+The last expression in a function body is its return value. Use `return` for early exits.
+
+```
+fn square(x) {
+    x * x
+}
+assert(square(4) == 16)
+
+fn abs(x) {
+    if x >= 0 { return x }
+    return -x
+}
+assert(abs(-5) == 5)
+```
+
+Functions without a `return` and no trailing expression return `nil`.
+
+## Closures
+
+Functions capture variables from their enclosing scope by reference. Changes to captured variables are visible to all closures that share them.
+
+```
+fn make_adder(n) {
+    return fn(x) { x + n }
+}
+let add5 = make_adder(5)
+assert(add5(3) == 8)
+```
+
+Closures can capture and mutate state:
+
+```
+fn make_counter() {
+    mut count = 0
+    return fn() {
+        count = count + 1
+        return count
+    }
+}
+let counter = make_counter()
+assert(counter() == 1)
+assert(counter() == 2)
+assert(counter() == 3)
+```
+
+Multiple closures can share the same mutable variable:
+
+```
+fn make_pair() {
+    mut val = 0
+    let getter = fn() { val }
+    let setter = fn(x) { val = x }
+    return [getter, setter]
+}
+let pair = make_pair()
+let get = pair[0]
+let set = pair[1]
+assert(get() == 0)
+set(42)
+assert(get() == 42)
+```
+
+## Higher-Order Functions
+
+Functions can accept and return other functions.
+
+```
+fn apply(f, x) {
+    return f(x)
+}
+assert(apply(fn(x) { x * x }, 5) == 25)
+```
+
+```
+fn compose(f, g) {
+    return fn(x) { f(g(x)) }
+}
+let inc = fn(x) { x + 1 }
+let dbl = fn(x) { x * 2 }
+let inc_then_dbl = compose(dbl, inc)
+assert(inc_then_dbl(3) == 8)
+```
+
+Common patterns like map, filter, and reduce:
+
+```
+fn filter(arr, pred) {
+    mut result = []
+    for x in arr {
+        if pred(x) { push(result, x) }
+    }
+    return result
+}
+let evens = filter([1, 2, 3, 4, 5, 6], fn(x) { x % 2 == 0 })
+assert(len(evens) == 3)
+
+fn reduce(arr, init, f) {
+    mut acc = init
+    for x in arr { acc = f(acc, x) }
+    return acc
+}
+assert(reduce([1, 2, 3, 4, 5], 0, fn(a, b) { a + b }) == 15)
+```
+
+## Recursion
+
+Named functions can call themselves. Use named function expressions (`fn name(params) { ... }`) when assigning a recursive function to a variable.
+
+```
+fn factorial(n) {
+    if n <= 1 { return 1 }
+    return n * factorial(n - 1)
+}
+assert(factorial(5) == 120)
+
+let fib = fn fib(n) {
+    if n < 2 { return n }
+    return fib(n - 1) + fib(n - 2)
+}
+assert(fib(10) == 55)
+```
+
+## Quick Reference
+
+| Feature | Syntax | Notes |
+|---------|--------|-------|
+| Named function | `fn name(a, b) { body }` | Hoisted in scope |
+| Anonymous function | `fn(a, b) { body }` | First-class value |
+| Named function expression | `let f = fn f(n) { ... }` | Enables recursion via variable |
+| Implicit return | last expression in body | No `return` needed |
+| Explicit return | `return expr` | Early exit |
+| Closure capture | automatic | By reference |


### PR DESCRIPTION
## Summary

- Add Astro Starlight documentation site configuration and content collection setup
- Add **5 circuit programming pages** with full content: declarations, builtins, operators & costs, functions in circuits, and control flow in circuits
- Add **3 language reference pages**: control flow, functions & closures, arrays & collections
- Add circuit programming overview and landing page
- Add stub pages for remaining sidebar sections (getting started, ZK concepts, CLI, architecture, tutorials)
- Move audit reports from `docs/` to `audits/` directory
- Add `.gitignore` entries for docs build artifacts (`docs/dist`, `docs/.astro`, `docs/node_modules`)

## Test plan

- [x] `pnpm build` in `docs/` succeeds (59 pages built)
- [x] Review circuit docs content for accuracy against codebase
- [x] Verify no broken sidebar links