### PR TITLE
feat: Add gradual type system for circuits

### DIFF
--- a/achronyme-parser/src/ast.rs
+++ b/achronyme-parser/src/ast.rs
@@ -20,11 +20,13 @@ pub struct Program {
 pub enum Stmt {
     LetDecl {
         name: String,
+        type_ann: Option<TypeAnnotation>,
         value: Expr,
         span: Span,
     },
     MutDecl {
         name: String,
+        type_ann: Option<TypeAnnotation>,
         value: Expr,
         span: Span,
     },
@@ -43,7 +45,8 @@ pub enum Stmt {
     },
     FnDecl {
         name: String,
-        params: Vec<String>,
+        params: Vec<TypedParam>,
+        return_type: Option<TypeAnnotation>,
         body: Block,
         span: Span,
     },
@@ -69,6 +72,7 @@ pub enum Stmt {
 pub struct InputDecl {
     pub name: String,
     pub array_size: Option<usize>,
+    pub type_ann: Option<TypeAnnotation>,
 }
 
 /// A block of statements (e.g., `{ ... }`).
@@ -150,7 +154,8 @@ pub enum Expr {
     Block(Block),
     FnExpr {
         name: Option<String>,
-        params: Vec<String>,
+        params: Vec<TypedParam>,
+        return_type: Option<TypeAnnotation>,
         body: Block,
         span: Span,
     },
@@ -240,4 +245,49 @@ pub enum BinOp {
 pub enum UnaryOp {
     Neg,
     Not,
+}
+
+/// A type annotation for circuit variables and function parameters.
+///
+/// ```
+/// use achronyme_parser::ast::TypeAnnotation;
+///
+/// let t = TypeAnnotation::Field;
+/// assert_eq!(format!("{t}"), "Field");
+///
+/// let arr = TypeAnnotation::BoolArray(4);
+/// assert_eq!(format!("{arr}"), "Bool[4]");
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TypeAnnotation {
+    Field,
+    Bool,
+    FieldArray(usize),
+    BoolArray(usize),
+}
+
+impl std::fmt::Display for TypeAnnotation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeAnnotation::Field => write!(f, "Field"),
+            TypeAnnotation::Bool => write!(f, "Bool"),
+            TypeAnnotation::FieldArray(n) => write!(f, "Field[{n}]"),
+            TypeAnnotation::BoolArray(n) => write!(f, "Bool[{n}]"),
+        }
+    }
+}
+
+/// A function parameter with an optional type annotation.
+///
+/// ```
+/// use achronyme_parser::ast::TypedParam;
+///
+/// let p = TypedParam { name: "x".into(), type_ann: None };
+/// assert_eq!(p.name, "x");
+/// assert!(p.type_ann.is_none());
+/// ```
+#[derive(Clone, Debug)]
+pub struct TypedParam {
+    pub name: String,
+    pub type_ann: Option<TypeAnnotation>,
 }

--- a/achronyme-parser/src/lexer.rs
+++ b/achronyme-parser/src/lexer.rs
@@ -242,6 +242,24 @@ impl<'a> Lexer<'a> {
                 }
                 return Err(ParseError::new("unexpected character `|`", sp.line, sp.col));
             }
+            b'-' => {
+                self.advance();
+                if self.peek() == Some(b'>') {
+                    self.advance();
+                    return Ok(Token {
+                        kind: TokenKind::Arrow,
+                        span: sp,
+                        lexeme: "->".into(),
+                        byte_offset: offset,
+                    });
+                }
+                return Ok(Token {
+                    kind: TokenKind::Minus,
+                    span: sp,
+                    lexeme: "-".into(),
+                    byte_offset: offset,
+                });
+            }
             b'.' => {
                 self.advance();
                 if self.peek() == Some(b'.') {
@@ -267,7 +285,6 @@ impl<'a> Lexer<'a> {
         self.advance();
         let (kind, lexeme) = match ch {
             b'+' => (TokenKind::Plus, "+"),
-            b'-' => (TokenKind::Minus, "-"),
             b'*' => (TokenKind::Star, "*"),
             b'/' => (TokenKind::Slash, "/"),
             b'%' => (TokenKind::Percent, "%"),

--- a/achronyme-parser/src/token.rs
+++ b/achronyme-parser/src/token.rs
@@ -59,6 +59,7 @@ pub enum TokenKind {
     Or,
     Not,
     Assign,
+    Arrow,
     DotDot,
     Dot,
 

--- a/compiler/src/functions.rs
+++ b/compiler/src/functions.rs
@@ -11,7 +11,7 @@ pub trait FunctionDefinitionCompiler {
     fn compile_fn_core(
         &mut self,
         name: Option<&str>,
-        params: &[String],
+        params: &[TypedParam],
         body: &Block,
     ) -> Result<u8, CompilerError>;
 }
@@ -20,7 +20,7 @@ impl FunctionDefinitionCompiler for Compiler {
     fn compile_fn_core(
         &mut self,
         name: Option<&str>,
-        params: &[String],
+        params: &[TypedParam],
         body: &Block,
     ) -> Result<u8, CompilerError> {
         let fn_name = name.unwrap_or("lambda").to_string();
@@ -49,7 +49,7 @@ impl FunctionDefinitionCompiler for Compiler {
 
         for (i, param) in params.iter().enumerate() {
             self.current().locals.push(Local {
-                name: param.clone(),
+                name: param.name.clone(),
                 depth: 0,
                 is_captured: false,
                 reg: i as u8,

--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -56,6 +56,26 @@ pub enum IrError {
         got: String,
         span: Option<SourceSpan>,
     },
+    /// A type annotation does not match the inferred type.
+    ///
+    /// ```
+    /// use ir::error::{IrError, SourceSpan};
+    ///
+    /// let err = IrError::AnnotationMismatch {
+    ///     name: "x".into(),
+    ///     declared: "Bool".into(),
+    ///     inferred: "Field".into(),
+    ///     span: Some(SourceSpan { line: 1, col: 5 }),
+    /// };
+    /// assert!(format!("{err}").contains("Bool"));
+    /// assert!(format!("{err}").contains("Field"));
+    /// ```
+    AnnotationMismatch {
+        name: String,
+        declared: String,
+        inferred: String,
+        span: Option<SourceSpan>,
+    },
 }
 
 impl fmt::Display for IrError {
@@ -163,6 +183,21 @@ impl fmt::Display for IrError {
                     write!(f, "[{s}] type mismatch: expected {expected}, got {got}")
                 } else {
                     write!(f, "type mismatch: expected {expected}, got {got}")
+                }
+            }
+            IrError::AnnotationMismatch {
+                name,
+                declared,
+                inferred,
+                span,
+            } => {
+                let msg = format!(
+                    "type annotation mismatch for `{name}`: declared as {declared}, but expression has type {inferred}"
+                );
+                if let Some(s) = span {
+                    write!(f, "[{s}] {msg}")
+                } else {
+                    write!(f, "{msg}")
                 }
             }
         }

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -6,4 +6,4 @@ pub mod types;
 
 pub use error::{IrError, SourceSpan};
 pub use lower::IrLowering;
-pub use types::{Instruction, IrProgram, SsaVar, Visibility};
+pub use types::{Instruction, IrProgram, IrType, SsaVar, Visibility};

--- a/ir/src/passes/bool_prop.rs
+++ b/ir/src/passes/bool_prop.rs
@@ -2,20 +2,40 @@ use std::collections::HashSet;
 
 use memory::FieldElement;
 
-use crate::types::{Instruction, IrProgram, SsaVar};
+use crate::types::{Instruction, IrProgram, IrType, SsaVar};
 
 /// Forward pass O(n) that computes the set of SSA variables proven to be boolean
 /// (i.e., their value is always 0 or 1).
 ///
-/// Seeds: `Const(0)`, `Const(1)`, `IsEq`, `IsNeq`, `IsLt`, `IsLe` results.
+/// Seeds: `Const(0)`, `Const(1)`, `IsEq`, `IsNeq`, `IsLt`, `IsLe` results,
+/// and any variable annotated as `Bool` via `program.var_types`.
 ///
 /// Propagation:
 /// - `Not(x)`: if x is boolean, result is boolean
 /// - `And(a, b)`: if both are boolean, result is boolean
 /// - `Or(a, b)`: if both are boolean, result is boolean
 /// - `Mux(_, t, f)`: if both branches are boolean, result is boolean
+///
+/// ```
+/// use ir::types::{IrProgram, IrType, Instruction, SsaVar, Visibility};
+/// use ir::passes::bool_prop::compute_proven_boolean;
+///
+/// let mut prog = IrProgram::new();
+/// let v = prog.fresh_var();
+/// prog.push(Instruction::Input { result: v, name: "b".into(), visibility: Visibility::Witness });
+/// prog.set_type(v, IrType::Bool);
+/// let booleans = compute_proven_boolean(&prog);
+/// assert!(booleans.contains(&v), "annotated Bool var should be in proven_boolean set");
+/// ```
 pub fn compute_proven_boolean(program: &IrProgram) -> HashSet<SsaVar> {
     let mut booleans = HashSet::new();
+
+    // Seed from type annotations: any variable annotated as Bool is proven boolean
+    for (var, ty) in &program.var_types {
+        if *ty == IrType::Bool {
+            booleans.insert(*var);
+        }
+    }
 
     for inst in &program.instructions {
         match inst {

--- a/ir/tests/taint_test.rs
+++ b/ir/tests/taint_test.rs
@@ -8,6 +8,7 @@ fn prog(instructions: Vec<Instruction>, next_var: u32) -> IrProgram {
         instructions,
         next_var,
         var_names: std::collections::HashMap::new(),
+        var_types: std::collections::HashMap::new(),
     }
 }
 

--- a/test/circuit/typed_arithmetic.ach
+++ b/test/circuit/typed_arithmetic.ach
@@ -1,0 +1,18 @@
+// Circuit: arithmetic with type annotations
+public out: Field
+witness a: Field
+witness b: Field
+
+// Typed let bindings
+let product: Field = a * b
+assert_eq(product, out)
+
+let sum: Field = a + b
+assert_eq(sum, a + b)
+
+let diff: Field = b - a
+assert_eq(diff, b - a)
+
+// Untyped let mixed with typed inputs (gradual typing)
+let doubled = a + a
+assert_eq(doubled, a * 2)

--- a/test/circuit/typed_arrays_and_functions.ach
+++ b/test/circuit/typed_arrays_and_functions.ach
@@ -1,0 +1,17 @@
+// Circuit: arrays and functions with type annotations
+public expected_sum: Field
+witness vals[3]: Field
+
+// Sum via accumulation
+let acc: Field = vals[0]
+let acc: Field = acc + vals[1]
+let acc: Field = acc + vals[2]
+assert_eq(acc, expected_sum)
+
+// len() returns compile-time constant
+let n: Field = len(vals)
+assert_eq(n, 3)
+
+// Typed function definition
+fn double(x: Field) -> Field { x + x }
+assert_eq(double(vals[0]), vals[0] + vals[0])

--- a/test/circuit/typed_boolean_ops.ach
+++ b/test/circuit/typed_boolean_ops.ach
@@ -1,0 +1,31 @@
+// Circuit: boolean operations with type annotations
+witness x: Field
+witness y: Field
+
+// Comparisons produce Bool
+let lt: Bool = x < y
+assert(lt)
+
+let le: Bool = x <= y
+assert(le)
+
+let gt: Bool = y > x
+assert(gt)
+
+let ge: Bool = y >= x
+assert(ge)
+
+// Logical operators on Bool
+let both: Bool = lt && gt
+assert(both)
+
+let either: Bool = (x == y) || (x < y)
+assert(either)
+
+// Logical NOT
+let not_eq: Bool = !(x == y)
+assert(not_eq)
+
+// Bool used in field context (subtyping: Bool -> Field)
+let eq: Bool = x == x
+let as_field: Field = eq + eq

--- a/test/circuit/typed_merkle.ach
+++ b/test/circuit/typed_merkle.ach
@@ -1,0 +1,7 @@
+// Circuit: Merkle membership proof with type annotations
+public root: Field
+witness leaf: Field
+witness path[1]: Field
+witness indices[1]: Bool
+
+merkle_verify(root, leaf, path, indices)

--- a/test/circuit/typed_mux.ach
+++ b/test/circuit/typed_mux.ach
@@ -1,0 +1,8 @@
+// Circuit: mux with type annotations
+public out: Field
+witness cond: Bool
+witness a: Field
+witness b: Field
+
+let selected: Field = mux(cond, a, b)
+assert_eq(selected, out)

--- a/test/circuit/typed_poseidon.ach
+++ b/test/circuit/typed_poseidon.ach
@@ -1,0 +1,14 @@
+// Circuit: Poseidon hash with type annotations
+public expected: Field
+witness a: Field
+witness b: Field
+witness c: Field
+
+// poseidon returns Field
+let h: Field = poseidon(a, b)
+assert_eq(h, expected)
+
+// poseidon_many also returns Field
+let folded: Field = poseidon(h, c)
+let many: Field = poseidon_many(a, b, c)
+assert_eq(many, folded)

--- a/test/prove/typed_prove.ach
+++ b/test/prove/typed_prove.ach
@@ -1,0 +1,15 @@
+// Prove block with type annotations
+let x = field(6)
+let y = field(7)
+let product = field(42)
+
+prove {
+    witness x: Field
+    witness y: Field
+    public product: Field
+
+    let result: Field = x * y
+    assert_eq(result, product)
+}
+
+print("PASS: typed_prove")

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -103,6 +103,40 @@ run_test "circuit/power.ach" \
     --r1cs "$R1CS_DIR/pow.r1cs" --wtns "$R1CS_DIR/pow.wtns" \
     --inputs "x=3,x2=9,x3=27,x4=81"
 
+# --- Typed circuit tests (gradual type system) ---
+echo ""
+echo "=== Typed circuit tests ==="
+
+run_test "circuit/typed_arithmetic.ach" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_arithmetic.ach" \
+    --r1cs "$R1CS_DIR/typed_arith.r1cs" --wtns "$R1CS_DIR/typed_arith.wtns" \
+    --inputs "out=42,a=6,b=7"
+
+run_test "circuit/typed_boolean_ops.ach" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_boolean_ops.ach" \
+    --r1cs "$R1CS_DIR/typed_bool.r1cs" --wtns "$R1CS_DIR/typed_bool.wtns" \
+    --inputs "x=3,y=5"
+
+run_test "circuit/typed_mux.ach" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_mux.ach" \
+    --r1cs "$R1CS_DIR/typed_mux.r1cs" --wtns "$R1CS_DIR/typed_mux.wtns" \
+    --inputs "out=42,cond=1,a=42,b=99"
+
+run_test "circuit/typed_arrays_and_functions.ach" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_arrays_and_functions.ach" \
+    --r1cs "$R1CS_DIR/typed_arr.r1cs" --wtns "$R1CS_DIR/typed_arr.wtns" \
+    --inputs "expected_sum=60,vals_0=10,vals_1=20,vals_2=30"
+
+run_test "circuit/typed_poseidon.ach" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_poseidon.ach" \
+    --r1cs "$R1CS_DIR/typed_poseidon.r1cs" --wtns "$R1CS_DIR/typed_poseidon.wtns" \
+    --inputs "expected=7853200120776062878684798364095072458815029376092732009249414926327459813530,a=1,b=2,c=3"
+
+run_test "circuit/typed_merkle.ach" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_merkle.ach" \
+    --r1cs "$R1CS_DIR/typed_merkle.r1cs" --wtns "$R1CS_DIR/typed_merkle.wtns" \
+    --inputs "root=7853200120776062878684798364095072458815029376092732009249414926327459813530,leaf=1,path_0=2,indices_0=0"
+
 # --- Solidity verifier test ---
 echo ""
 echo "=== Solidity verifier tests ==="

--- a/test/vm/data_types/typed_bindings.ach
+++ b/test/vm/data_types/typed_bindings.ach
@@ -1,0 +1,29 @@
+// Type annotations on let/mut bindings (VM mode)
+// Annotations are parsed but VM execution is untyped — this verifies
+// that typed syntax is accepted without errors.
+
+// Typed let bindings
+let x: Field = field(42)
+assert(x == field(42))
+
+let flag: Bool = true
+assert(flag == true)
+
+// Typed mut bindings
+mut counter: Field = field(0)
+counter = field(10)
+assert(counter == field(10))
+
+mut ok: Bool = false
+ok = true
+assert(ok == true)
+
+// Untyped bindings still work (gradual typing)
+let y = 100
+assert(y == 100)
+
+mut z = "hello"
+z = "world"
+assert(z == "world")
+
+print("PASS: data_types/typed_bindings")

--- a/test/vm/functions/typed_functions.ach
+++ b/test/vm/functions/typed_functions.ach
@@ -1,0 +1,40 @@
+// Functions with type annotations (VM mode)
+// Annotations are parsed but VM execution is untyped — this verifies
+// that typed function syntax is accepted without errors.
+
+// Named function with typed params and return type
+fn add(a: Field, b: Field) -> Field {
+    return a + b
+}
+assert(add(3, 4) == 7)
+
+// Mixed: some params typed, some not
+fn scale(x: Field, factor) {
+    return x * factor
+}
+assert(scale(5, 3) == 15)
+
+// Return type annotation only
+fn square(x) -> Field {
+    x * x
+}
+assert(square(4) == 16)
+
+// Anonymous function with type annotations
+let double = fn(x: Field) -> Field { x * 2 }
+assert(double(5) == 10)
+
+// Higher-order: typed function as argument
+fn apply(f, x: Field) -> Field {
+    return f(x)
+}
+assert(apply(fn(x) { x * x }, 5) == 25)
+
+// Bool return type
+fn is_positive(x: Field) -> Bool {
+    return x > 0
+}
+assert(is_positive(5) == true)
+assert(is_positive(0) == false)
+
+print("PASS: functions/typed_functions")


### PR DESCRIPTION
## Summary

- Add optional type annotations (`Field`, `Bool`, `Field[N]`, `Bool[N]`) to variable declarations, function parameters, and return types
- `Bool` is a subtype of `Field` — boolean values can be used where field elements are expected
- `Field` and `Bool` are contextual identifiers (not keywords), recognized only after `:` or `->`
- Unannotated code has zero behavioral change (gradual typing)
- Annotated `Bool` witnesses skip redundant boolean enforcement, saving 1 constraint each

## Changes

### Phase 1: Parser (`achronyme-parser/`)
- `TypeAnnotation` enum, `TypedParam` struct, `Arrow` token (`->`)
- Parser helpers: `try_parse_type_annotation()`, `try_parse_return_type()`, `parse_type()`
- Updated `let`, `mut`, `public`/`witness`, `fn` declarations to accept optional type syntax
- ~20 new parser tests

### Phase 2: IR Type Metadata (`ir/src/types.rs`)
- `IrType` enum (`Field`, `Bool`) with `Display` impl
- `var_types: HashMap<SsaVar, IrType>` on `IrProgram` with `set_type`/`get_type`

### Phase 3: Type Checking in Lowering (`ir/src/lower.rs`)
- Validate annotations against inferred types during AST→IR lowering
- Arithmetic results → `Field`, comparison/logical results → `Bool`
- `Bool` used in arithmetic context → allowed (subtyping)
- `Field` annotated as `Bool` → `AnnotationMismatch` error with span
- 16 new type checking tests

### Phase 4: Bytecode Compiler (`compiler/src/functions.rs`)
- Update `compile_fn_core` params from `&[String]` to `&[TypedParam]`

### Phase 5: Bool Propagation (`ir/src/passes/bool_prop.rs`)
- Seed `proven_boolean` set from `program.var_types` — annotated `Bool` witnesses skip boolean enforcement

### Integration Tests (`test/`)
- 6 typed circuit tests, 2 typed VM tests, 1 typed prove test
- Updated `run_tests.sh` with typed circuit entries

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (all existing + new tests pass)
- [x] `bash test/run_tests.sh` (63/64 pass — 1 pre-existing unrelated failure)