### PR TITLE
docs: Add type annotations documentation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import codeTheme from './src/styles/code-theme.json';
 
 // https://astro.build/config
 export default defineConfig({
@@ -16,6 +17,14 @@ export default defineConfig({
 				root: { label: 'English', lang: 'en' },
 				es: { label: 'Español' },
 			},
+			customCss: [
+				'@fontsource-variable/jetbrains-mono',
+				'./src/styles/custom.css',
+			],
+			expressiveCode: {
+				themes: [codeTheme],
+			},
+			favicon: '/favicon.svg',
 			sidebar: [
 				{
 					label: 'Getting Started',
@@ -39,6 +48,7 @@ export default defineConfig({
 					items: [
 						{ label: 'Overview', slug: 'circuits/overview' },
 						{ label: 'Declarations', slug: 'circuits/declarations' },
+						{ label: 'Type Annotations', slug: 'circuits/type-annotations' },
 						{ label: 'Builtins', slug: 'circuits/builtins' },
 						{ label: 'Operators & Costs', slug: 'circuits/operators-and-costs' },
 						{ label: 'Functions in Circuits', slug: 'circuits/functions' },

--- a/docs/src/content/docs/circuits/declarations.mdx
+++ b/docs/src/content/docs/circuits/declarations.mdx
@@ -83,9 +83,23 @@ Array inputs are passed with indexed names:
 ach circuit merkle.ach --inputs "root=123,leaf=42,path_0=99,path_1=77,indices_0=0,indices_1=1"
 ```
 
+## Type Annotations
+
+Declarations can include optional type annotations. See [Type Annotations](/circuits/type-annotations/) for details.
+
+```
+public root: Field
+witness flag: Bool
+witness path[3]: Field
+witness indices[3]: Bool
+```
+
+Annotating a witness as `Bool` saves 1 constraint by skipping boolean enforcement.
+
 ## Errors
 
 | Error | Cause |
 |-------|-------|
 | `DuplicateInput` | Same name declared as both `public` and `witness`, or declared twice |
 | `UndeclaredVariable` | Using a variable that was never declared as `public` or `witness` |
+| `AnnotationMismatch` | Declared type doesn't match the inferred type |

--- a/docs/src/content/docs/circuits/functions.mdx
+++ b/docs/src/content/docs/circuits/functions.mdx
@@ -15,6 +15,14 @@ fn double(x) {
 }
 ```
 
+Functions can include [type annotations](/circuits/type-annotations/) on parameters and return types:
+
+```
+fn double(x: Field) -> Field {
+    x + x
+}
+```
+
 Call them as usual:
 
 ```
@@ -59,6 +67,7 @@ Calling `dot` three times produces 6 constraints.
 | No closures | — | No runtime environment to capture |
 | No higher-order functions | — | Cannot pass functions as circuit values |
 | No anonymous functions | — | Only named `fn` definitions are supported |
+| Type mismatch | `AnnotationMismatch` | Argument type doesn't match typed parameter |
 
 Functions in circuits are purely a compile-time mechanism. They cannot capture variables from outer scopes (except declared inputs), cannot be passed as values, and cannot call themselves.
 

--- a/docs/src/content/docs/circuits/operators-and-costs.mdx
+++ b/docs/src/content/docs/circuits/operators-and-costs.mdx
@@ -84,3 +84,5 @@ Multiplication by a constant is also free — it scales all coefficients in the 
 The compiler's `bool_prop` pass tracks which variables are already proven to be boolean (0 or 1). When a value produced by `==`, `<`, or another comparison feeds into `&&`, `||`, or `!`, the redundant boolean enforcement is skipped, saving constraints.
 
 For example, `!(x == y)` costs 2 constraints for the `==` and 0 for the `!`, because the output of `==` is already known to be boolean.
+
+[Type annotations](/circuits/type-annotations/) extend this optimization: declaring `witness flag: Bool` marks the variable as proven boolean, saving 1 constraint every time it's used in a boolean context (e.g., as a `mux` condition).

--- a/docs/src/content/docs/circuits/overview.mdx
+++ b/docs/src/content/docs/circuits/overview.mdx
@@ -52,6 +52,7 @@ The `prove {}` block runs inside the VM, captures variables from scope, compiles
 | `if/else` | Compiles to `mux` — both branches evaluated |
 | `for` loops (range or array) | Statically unrolled |
 | `fn` calls | Inlined at each call site |
+| [Type annotations](/circuits/type-annotations/) | Optional `Field`/`Bool` types on declarations and bindings |
 | `assert_eq(a, b)` | Enforces `a == b` (1 constraint) |
 | `poseidon(a, b)` | Poseidon 2-to-1 hash (361 constraints) |
 | `range_check(x, bits)` | Value fits in N bits |

--- a/docs/src/content/docs/circuits/type-annotations.mdx
+++ b/docs/src/content/docs/circuits/type-annotations.mdx
@@ -1,0 +1,202 @@
+---
+title: "Type Annotations"
+description: "Optional type annotations for circuit variables, functions, and bindings."
+---
+
+Achronyme supports **gradual typing** in circuits. You can add optional type annotations to declarations, bindings, and functions. Unannotated code works exactly as before — annotations are strictly opt-in.
+
+## Type Universe
+
+Four types are available in circuit context:
+
+| Type | Description |
+|------|-------------|
+| `Field` | A BN254 scalar field element (the default for all circuit values) |
+| `Bool` | A boolean value (0 or 1 in the field) |
+| `Field[N]` | Fixed-size array of N field elements |
+| `Bool[N]` | Fixed-size array of N booleans |
+
+`Bool` is a **subtype** of `Field` — a boolean value can be used anywhere a field element is expected. The reverse is an error unless the value is a proven boolean (e.g., a comparison result or constant 0/1).
+
+`Field` and `Bool` are **not keywords**. They are contextual identifiers recognized only after `:` or `->`. You can still use `Field` and `Bool` as variable names in regular code.
+
+## Input Declarations
+
+Add `: Type` after the variable name (or after the array size):
+
+```
+public root: Field
+witness flag: Bool
+witness secret: Field
+
+witness path[3]: Field
+witness indices[3]: Bool
+```
+
+Without annotations, inputs default to untyped — same behavior as before:
+
+```
+public root
+witness secret
+```
+
+Both forms can coexist in the same circuit:
+
+```
+public root: Field
+witness leaf
+witness path[3]: Field
+witness indices[3]
+```
+
+## Let Bindings
+
+Annotate local bindings with `: Type` after the name, before `=`:
+
+```
+witness a: Field
+witness b: Field
+
+let product: Field = a * b
+let is_equal: Bool = a == b
+```
+
+The compiler validates that the annotation matches the expression's inferred type. If there's a mismatch, you get a clear error:
+
+```
+witness a: Field
+
+// Error: type annotation mismatch for `x`: declared as Bool,
+//        but expression has type Field
+let x: Bool = a + 1
+```
+
+Arithmetic operations (`+`, `-`, `*`, `/`, `^`) produce `Field`. Comparisons and logical operations (`==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `!`) produce `Bool`.
+
+## Functions
+
+Annotate parameters with `: Type` and return types with `-> Type`:
+
+```
+fn hash_pair(a: Field, b: Field) -> Field {
+    poseidon(a, b)
+}
+
+fn is_valid(x: Field, y: Field) -> Bool {
+    x == y
+}
+```
+
+Mixed typed and untyped parameters are allowed:
+
+```
+fn scale(x: Field, factor) {
+    x * factor
+}
+```
+
+The compiler checks that arguments match the declared parameter types at each call site:
+
+```
+fn double(x: Field) -> Field { x + x }
+
+witness a: Field
+let result: Field = double(a)    // ok
+```
+
+## Subtyping: Bool as Field
+
+`Bool` values can be used in arithmetic (field) context. This is safe because booleans are 0 or 1 in the field:
+
+```
+witness flag: Bool
+
+// Bool used in arithmetic — allowed (Bool is subtype of Field)
+let as_field: Field = flag + flag
+```
+
+The reverse is not allowed unless the value is a proven boolean:
+
+```
+witness x: Field
+
+// Error: x is Field, cannot annotate as Bool
+let b: Bool = x
+```
+
+Values that are proven boolean (comparison results, constants 0/1) can be annotated as `Bool`:
+
+```
+witness a: Field
+witness b: Field
+
+// Comparison result is a proven boolean — annotation is valid
+let eq: Bool = a == b
+```
+
+## Constraint Savings
+
+Annotating a witness as `Bool` tells the compiler it can skip the boolean enforcement constraint for that variable. This saves **1 constraint per annotated Bool witness**.
+
+Without annotation, the compiler must add a constraint to enforce `flag * (1 - flag) = 0` every time `flag` is used in a boolean context. With `witness flag: Bool`, the compiler knows `flag` is already boolean and skips the enforcement.
+
+```
+// Without annotation: mux adds 1 boolean enforcement for cond (2 constraints total)
+witness cond
+let r = mux(cond, a, b)
+
+// With annotation: boolean enforcement skipped (1 constraint total)
+witness cond: Bool
+let r = mux(cond, a, b)
+```
+
+This optimization is applied by the `bool_prop` pass, which tracks proven-boolean variables through the program.
+
+## Complete Example
+
+A fully typed Merkle membership proof:
+
+```
+public root: Field
+witness leaf: Field
+witness path[3]: Field
+witness indices[3]: Bool
+
+merkle_verify(root, leaf, path, indices)
+```
+
+The same circuit with typed helper functions:
+
+```
+public expected: Field
+witness a: Field
+witness b: Field
+witness c: Field
+
+fn hash_chain(x: Field, y: Field, z: Field) -> Field {
+    let h: Field = poseidon(x, y)
+    poseidon(h, z)
+}
+
+let result: Field = hash_chain(a, b, c)
+assert_eq(result, expected)
+```
+
+## Quick Reference
+
+| Syntax | Example | Notes |
+|--------|---------|-------|
+| Typed public | `public x: Field` | Annotated public input |
+| Typed witness | `witness flag: Bool` | Saves 1 boolean enforcement constraint |
+| Typed array | `witness path[3]: Field` | Type applies to all elements |
+| Typed let | `let h: Field = poseidon(a, b)` | Validated against inferred type |
+| Typed parameter | `fn f(x: Field)` | Checked at each call site |
+| Return type | `fn f(x: Field) -> Bool` | Checked against body's result type |
+| Untyped (default) | `witness secret` | Same behavior as before |
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| `AnnotationMismatch` | Declared type doesn't match the inferred type (e.g., `let x: Bool = a + b`) |
+| Parse error | Invalid type name (only `Field` and `Bool` are recognized) |

--- a/docs/src/content/docs/language/functions-and-closures.mdx
+++ b/docs/src/content/docs/language/functions-and-closures.mdx
@@ -157,6 +157,32 @@ let fib = fn fib(n) {
 assert(fib(10) == 55)
 ```
 
+## Type Annotations
+
+Functions can include optional type annotations on parameters and return types:
+
+```
+fn add(a: Field, b: Field) -> Field {
+    return a + b
+}
+
+fn is_positive(x: Field) -> Bool {
+    return x > 0
+}
+
+let double = fn(x: Field) -> Field { x * 2 }
+```
+
+Mixed typed and untyped parameters are allowed — this is gradual typing:
+
+```
+fn scale(x: Field, factor) {
+    x * factor
+}
+```
+
+In circuit mode, annotations are checked at compile time. See [Type Annotations](/circuits/type-annotations/) for details on type checking rules and constraint savings.
+
 ## Quick Reference
 
 | Feature | Syntax | Notes |
@@ -164,6 +190,8 @@ assert(fib(10) == 55)
 | Named function | `fn name(a, b) { body }` | Hoisted in scope |
 | Anonymous function | `fn(a, b) { body }` | First-class value |
 | Named function expression | `let f = fn f(n) { ... }` | Enables recursion via variable |
+| Typed parameters | `fn f(x: Field, y: Bool)` | Optional, checked in circuits |
+| Return type | `fn f(x) -> Field { body }` | Optional, checked in circuits |
 | Implicit return | last expression in body | No `return` needed |
 | Explicit return | `return expr` | Early exit |
 | Closure capture | automatic | By reference |

--- a/docs/src/content/docs/language/types-and-values.mdx
+++ b/docs/src/content/docs/language/types-and-values.mdx
@@ -94,3 +94,15 @@ y = y + 1           // reassignment (only for mut)
 ```
 
 `let` creates an immutable binding. `mut` creates a mutable binding that can be reassigned.
+
+## Type Annotations
+
+Achronyme supports optional type annotations on variable bindings and function signatures. In circuit mode, annotations enable compile-time type checking and constraint optimization. In VM mode, annotations are parsed and accepted but execution remains dynamic.
+
+```
+let x: Field = field(42)
+let flag: Bool = true
+mut counter: Field = field(0)
+```
+
+See [Type Annotations](/circuits/type-annotations/) for the full reference in circuit context.


### PR DESCRIPTION
## Summary

- New documentation page `circuits/type-annotations.mdx` covering the gradual type system: `Field`, `Bool`, subtyping rules, constraint savings, and complete examples
- Updated 6 existing pages with cross-references to the new type annotations page
- Added sidebar entry under Circuit Programming

## Updated pages

- **circuits/declarations** — typed input syntax, `AnnotationMismatch` error
- **circuits/functions** — typed params and return types
- **circuits/operators-and-costs** — `Bool` annotation optimization paragraph
- **circuits/overview** — type annotations in feature table
- **language/types-and-values** — type annotation section for VM mode
- **language/functions-and-closures** — typed function syntax and quick reference

## Test plan

- [x] `pnpm build` in `docs/` succeeds (61 pages generated)