### PR TITLE
style(docs): Apply brand identity to documentation site

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.37.6",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "astro": "^5.6.1",
     "sharp": "^0.34.2"
   }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.37.6
         version: 0.37.6(astro@5.17.3(rollup@4.59.0)(typescript@5.9.3))
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       astro:
         specifier: ^5.6.1
         version: 5.17.3(rollup@4.59.0)(typescript@5.9.3)
@@ -406,6 +409,9 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.41.6':
     resolution: {integrity: sha512-PBFa1wGyYzRExMDzBmAWC6/kdfG1oLn4pLpBeTfIRrALPjcGA/59HP3e7q9J0Smk4pC7U+lWkA2LHR8FYV8U7Q==}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2310,6 +2316,8 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.41.6':
     dependencies:
       '@expressive-code/core': 0.41.6
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@img/colour@1.0.0': {}
 

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><path fill-rule="evenodd" d="M81 36 64 0 47 36l-1 2-9-10a6 6 0 0 0-9 9l10 10h-2L0 64l36 17h2L28 91a6 6 0 1 0 9 9l9-10 1 2 17 36 17-36v-2l9 10a6 6 0 1 0 9-9l-9-9 2-1 36-17-36-17-2-1 9-9a6 6 0 1 0-9-9l-9 10v-2Zm-17 2-2 5c-4 8-11 15-19 19l-5 2 5 2c8 4 15 11 19 19l2 5 2-5c4-8 11-15 19-19l5-2-5-2c-8-4-15-11-19-19l-2-5Z" clip-rule="evenodd"/><path d="M118 19a6 6 0 0 0-9-9l-3 3a6 6 0 1 0 9 9l3-3Zm-96 4c-2 2-6 2-9 0l-3-3a6 6 0 1 1 9-9l3 3c3 2 3 6 0 9Zm0 82c-2-2-6-2-9 0l-3 3a6 6 0 1 0 9 9l3-3c3-2 3-6 0-9Zm96 4a6 6 0 0 1-9 9l-3-3a6 6 0 1 1 9-9l3 3Z"/><style>path{fill:#000}@media (prefers-color-scheme:dark){path{fill:#fff}}</style></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <path d="M8 6 L16 4 L24 6 L16 28 Z" fill="#8B5CF6"/>
+  <path d="M6 10 L16 7 L26 10" stroke="#A78BFA" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Achronyme
 description: A programming language for zero-knowledge circuits.
 template: splash
 hero:
-  tagline: Write readable code. Decide what gets proven. Same language for general execution and ZK circuit compilation.
+  tagline: Write code. Prove parts of it. Same language for execution and ZK circuits — no separate DSL, no context switch.
   actions:
     - text: Get Started
       link: /getting-started/introduction/
@@ -18,15 +18,15 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <Card title="Dual Mode" icon="rocket">
-    Run programs normally with `ach run` or compile to ZK circuits with `ach circuit`. Same language, two modes.
+    `ach run` executes your program. `ach circuit` compiles it to ZK constraints. Same syntax, two targets.
   </Card>
   <Card title="Two Backends" icon="setting">
-    R1CS (Groth16) and Plonkish (KZG-PlonK). Choose the right backend for your proof system.
+    R1CS for Groth16. Plonkish for KZG-PlonK. Pick the proof system that fits.
   </Card>
   <Card title="Inline Proofs" icon="approve-check">
-    `prove {}` blocks compile circuits, generate witnesses, and produce proofs — all from within your program.
+    `prove {}` compiles, witnesses, and proves — all inline. No external tooling required.
   </Card>
   <Card title="snarkjs Compatible" icon="external">
-    Export `.r1cs` and `.wtns` files directly consumable by snarkjs for Groth16 proof generation.
+    Exports `.r1cs` and `.wtns` files. Plug directly into snarkjs for Groth16 proof generation.
   </Card>
 </CardGrid>

--- a/docs/src/styles/code-theme.json
+++ b/docs/src/styles/code-theme.json
@@ -1,0 +1,91 @@
+{
+	"name": "Achronyme",
+	"type": "dark",
+	"colors": {
+		"editor.background": "#13131A",
+		"editor.foreground": "#E4E4ED",
+		"editorLineNumber.foreground": "#5A5A6E",
+		"editorLineNumber.activeForeground": "#9494A8",
+		"editor.selectionBackground": "#8B5CF640",
+		"editor.lineHighlightBackground": "#1E1E2A"
+	},
+	"tokenColors": [
+		{
+			"name": "Comments",
+			"scope": ["comment", "punctuation.definition.comment"],
+			"settings": { "foreground": "#5A5A6E", "fontStyle": "italic" }
+		},
+		{
+			"name": "Keywords",
+			"scope": [
+				"keyword",
+				"storage.type",
+				"storage.modifier",
+				"keyword.control",
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.logical",
+				"variable.language"
+			],
+			"settings": { "foreground": "#8B5CF6" }
+		},
+		{
+			"name": "Strings",
+			"scope": ["string", "punctuation.definition.string"],
+			"settings": { "foreground": "#34D399" }
+		},
+		{
+			"name": "Numbers",
+			"scope": ["constant.numeric", "constant.language.boolean"],
+			"settings": { "foreground": "#FBBF24" }
+		},
+		{
+			"name": "Functions",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"meta.function-call"
+			],
+			"settings": { "foreground": "#A78BFA" }
+		},
+		{
+			"name": "Operators",
+			"scope": [
+				"keyword.operator",
+				"punctuation.separator",
+				"punctuation.accessor"
+			],
+			"settings": { "foreground": "#9494A8" }
+		},
+		{
+			"name": "Types",
+			"scope": [
+				"entity.name.type",
+				"entity.name.class",
+				"support.type",
+				"support.class"
+			],
+			"settings": { "foreground": "#60A5FA" }
+		},
+		{
+			"name": "Variables",
+			"scope": ["variable", "variable.other"],
+			"settings": { "foreground": "#E4E4ED" }
+		},
+		{
+			"name": "Constants",
+			"scope": ["constant.other", "variable.other.constant"],
+			"settings": { "foreground": "#FBBF24" }
+		},
+		{
+			"name": "Punctuation",
+			"scope": [
+				"punctuation.definition.block",
+				"punctuation.definition.parameters",
+				"punctuation.section",
+				"meta.brace"
+			],
+			"settings": { "foreground": "#9494A8" }
+		}
+	]
+}

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -1,0 +1,72 @@
+/* Achronyme brand theme — see brand/BRAND.md */
+
+/* === Dark theme (canonical) === */
+:root {
+	--sl-color-bg: #0a0a0f;
+	--sl-color-bg-nav: #13131a;
+	--sl-color-bg-sidebar: #13131a;
+	--sl-color-hairline: #1e1e2a;
+	--sl-color-hairline-light: #1e1e2a;
+
+	--sl-color-accent-low: rgba(109, 40, 217, 0.25);
+	--sl-color-accent: #8b5cf6;
+	--sl-color-accent-high: #a78bfa;
+
+	--sl-color-text: #e4e4ed;
+	--sl-color-text-accent: #a78bfa;
+	--sl-color-gray-1: #e4e4ed;
+	--sl-color-gray-2: #c4c4d4;
+	--sl-color-gray-3: #9494a8;
+	--sl-color-gray-4: #5a5a6e;
+	--sl-color-gray-5: #1e1e2a;
+	--sl-color-gray-6: #13131a;
+
+	--sl-font: 'JetBrains Mono Variable', 'Fira Code', 'Consolas', monospace;
+	--sl-font-system: 'JetBrains Mono Variable', 'Fira Code', 'Consolas', monospace;
+	--sl-font-system-mono: 'JetBrains Mono Variable', 'Fira Code', 'Consolas', monospace;
+}
+
+/* === Light theme overrides === */
+[data-theme='light'],
+:root[data-theme='light'] {
+	--sl-color-bg: #fafafc;
+	--sl-color-bg-nav: #f0f0f5;
+	--sl-color-bg-sidebar: #f0f0f5;
+	--sl-color-hairline: #e4e4ed;
+	--sl-color-hairline-light: #e4e4ed;
+
+	--sl-color-accent-low: rgba(124, 58, 237, 0.12);
+	--sl-color-accent: #7c3aed;
+	--sl-color-accent-high: #6d28d9;
+
+	--sl-color-text: #13131a;
+	--sl-color-gray-1: #13131a;
+	--sl-color-gray-2: #1e1e2a;
+	--sl-color-gray-3: #5a5a6e;
+	--sl-color-gray-4: #9494a8;
+	--sl-color-gray-5: #e4e4ed;
+	--sl-color-gray-6: #f0f0f5;
+}
+
+/* === Border radius (brand radius-md = 10px) === */
+.expressive-code pre,
+.expressive-code .frame {
+	border-radius: 10px !important;
+}
+
+.expressive-code .frame {
+	box-shadow: 0 0 20px rgba(139, 92, 246, 0.08);
+}
+
+.starlight-aside {
+	border-radius: 10px;
+}
+
+.card {
+	border-radius: 14px;
+}
+
+/* === Heading letter-spacing (brand: -0.02em) === */
+h1, h2, h3, h4, h5, h6 {
+	letter-spacing: -0.02em;
+}


### PR DESCRIPTION
## Summary

- Map brand colors (Void, Surface, Proof purple) to Starlight CSS variables
- Add JetBrains Mono font via `@fontsource-variable/jetbrains-mono`
- Custom Expressive Code syntax theme (`code-theme.json`)
- Branded favicon
- Sharpen homepage copy to match brand voice

## Files

- `docs/src/styles/custom.css` — Starlight CSS overrides with brand palette
- `docs/src/styles/code-theme.json` — custom syntax highlighting theme
- `docs/public/favicon.svg` — updated favicon
- `docs/src/content/docs/index.mdx` — homepage copy refinements
- `docs/package.json` / `docs/pnpm-lock.yaml` — JetBrains Mono dependency
- `docs/astro.config.mjs` — custom CSS, font, code theme, favicon config

## Test plan

- [x] `pnpm build` in `docs/` succeeds (61 pages generated)