### PR TITLE
chore: Update repo URLs after org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Achronyme
 
-[![CI](https://github.com/eddndev/achronyme/actions/workflows/ci.yml/badge.svg)](https://github.com/eddndev/achronyme/actions/workflows/ci.yml)
-[![Deploy Docs](https://github.com/eddndev/achronyme/actions/workflows/docs.yml/badge.svg)](https://github.com/eddndev/achronyme/actions/workflows/docs.yml)
+[![CI](https://github.com/achronyme/achronyme/actions/workflows/ci.yml/badge.svg)](https://github.com/achronyme/achronyme/actions/workflows/ci.yml)
+[![Deploy Docs](https://github.com/achronyme/achronyme/actions/workflows/docs.yml/badge.svg)](https://github.com/achronyme/achronyme/actions/workflows/docs.yml)
 
 A programming language for zero-knowledge circuits.
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,7 +10,7 @@ export default defineConfig({
 		starlight({
 			title: 'Achronyme Docs',
 			social: [
-				{ icon: 'github', label: 'GitHub', href: 'https://github.com/eddndev/achronyme' },
+				{ icon: 'github', label: 'GitHub', href: 'https://github.com/achronyme/achronyme' },
 			],
 			defaultLocale: 'root',
 			locales: {

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -8,7 +8,7 @@ description: How to install and build Achronyme.
 Achronyme is written in Rust. You need a recent Rust toolchain (1.77+).
 
 ```bash
-git clone https://github.com/eddndev/achronyme.git
+git clone https://github.com/achronyme/achronyme.git
 cd achronyme
 cargo build --release
 ```

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
       link: /getting-started/introduction/
       icon: right-arrow
     - text: View on GitHub
-      link: https://github.com/eddndev/achronyme
+      link: https://github.com/achronyme/achronyme
       variant: minimal
       icon: github
 ---


### PR DESCRIPTION
## Summary

- Update all `eddndev/achronyme` references to `achronyme/achronyme` after repo transfer

## Files

- `README.md` — CI and Deploy Docs badge URLs
- `docs/astro.config.mjs` — GitHub social link
- `docs/src/content/docs/index.mdx` — homepage GitHub link
- `docs/src/content/docs/getting-started/installation.mdx` — git clone URL

## Test plan

- [x] `grep -r eddndev/achronyme` returns no matches