### PR TITLE
fix: remove silent Int→Field promotion, resolve T-04/T-05/T-06

### DIFF
--- a/audits/AUDIT-2026-02-25.md
+++ b/audits/AUDIT-2026-02-25.md
@@ -4,7 +4,7 @@ Audit of the gradual type system for circuits (PR #19 + soundness fixes). Covers
 type annotation parsing, IR lowering with enforcement, `bool_prop` pass, and backend
 constraint-skipping logic.
 
-Workspace state: 887 tests passing, 0 failures.
+Workspace state: 894 tests passing, 0 failures.
 
 ---
 
@@ -14,9 +14,9 @@ Workspace state: 887 tests passing, 0 failures.
 |----------|-------|------|-----|
 | High     | 1     | 0    | ~~T-01~~ |
 | Medium   | 2     | 0    | ~~T-02~~, ~~T-03~~ |
-| Low      | 3     | 3    | T-04, T-05, T-06 |
+| Low      | 3     | 0    | ~~T-04~~, ~~T-05~~, ~~T-06~~ |
 
-**T-01, T-02, T-03 fixed.** 887 workspace tests passing.
+**All findings fixed.** 894 workspace tests passing.
 
 ---
 
@@ -102,7 +102,7 @@ Workspace state: 887 tests passing, 0 failures.
 
 ## Low (3)
 
-### T-04: Scalar annotation on array / array annotation on scalar silently accepted — OPEN
+### T-04: Scalar annotation on array / array annotation on scalar silently accepted — FIXED
 
 - **File**: `ir/src/lower.rs` (`lower_let`)
 - **Issue**: The `lower_let` function dispatches to the array path only when the RHS is
@@ -116,12 +116,15 @@ Workspace state: 887 tests passing, 0 failures.
   Neither case produces an error. While not a soundness issue (enforcement works
   correctly in both paths), it allows confusing code to compile silently.
 
-  **Fix**: Validate that `FieldArray`/`BoolArray` annotations only appear with array
-  values, and scalar `Field`/`Bool` annotations only appear with scalar values.
+- **Resolution**: Added shape validation in `lower_let`: array path rejects scalar
+  annotations (`Field`/`Bool`) with `TypeMismatch` error, scalar path rejects array
+  annotations (`FieldArray`/`BoolArray`) with `TypeMismatch` error. Tests:
+  `scalar_annotation_on_array_rejected`, `scalar_field_annotation_on_array_rejected`,
+  `array_annotation_on_scalar_rejected`, `array_bool_annotation_on_scalar_rejected`.
 
-### T-05: `pow_by_squaring` intermediate and final results untyped — OPEN
+### T-05: `pow_by_squaring` intermediate and final results untyped — FIXED
 
-- **File**: `ir/src/lower.rs` (`pow_by_squaring`)
+- **File**: `ir/src/lower.rs` (`pow_by_squaring`, `lower_binop` Pow path)
 - **Issue**: The `pow_by_squaring` function emits `Mul` instructions for `x ^ n` but
   doesn't call `set_type(v, IrType::Field)` on intermediate or final result variables.
   All other arithmetic operations in `lower_binop` (`Add`, `Sub`, `Mul`, `Div`) set
@@ -131,10 +134,12 @@ Workspace state: 887 tests passing, 0 failures.
   constraints are always emitted). But creates an inconsistency: `x * x` produces a
   `Field`-typed result while `x ^ 2` produces an untyped result.
 
-  **Fix**: Add `self.program.set_type(v, IrType::Field)` after each `Mul` in
-  `pow_by_squaring` and after the `Const(1)` for `exp == 0`.
+- **Resolution**: Added `self.program.set_type(v, IrType::Field)` after each `Mul` in
+  `pow_by_squaring`, after the `Const(1)` for `exp == 0` in `pow_by_squaring`, and
+  after the early `Const(1)` for `exp == 0` in the `lower_binop` Pow path. Tests:
+  `pow_result_has_field_type`, `pow_zero_result_has_field_type`.
 
-### T-06: `Field[N]` annotation overwrites `Bool` type on elements — OPEN
+### T-06: `Field[N]` annotation overwrites `Bool` type on elements — FIXED
 
 - **File**: `ir/src/lower.rs` (`lower_let` array path)
 - **Issue**: In the `lower_let` array path for `Field[N]` annotations:
@@ -152,9 +157,9 @@ Workspace state: 887 tests passing, 0 failures.
   may still be boolean from structural analysis (e.g., comparison result). This can
   lead to unnecessary boolean enforcement constraints (extra cost, not unsound).
 
-  **Fix**: Check `type_compatible(Field, inferred)` before overwriting. Since `Bool`
-  is subtype of `Field`, this is always compatible, but the code should preserve the
-  more specific type (`Bool`) rather than widening to `Field`.
+- **Resolution**: Changed `Field[N]` annotation loop to skip elements already typed as
+  `Bool`, preserving the more specific type. Test:
+  `field_array_preserves_bool_element_type`.
 
 ---
 
@@ -195,6 +200,6 @@ Workspace state: 887 tests passing, 0 failures.
 | T-01 | `enforce_input_type_ann()` helper emits `RangeCheck(v, 1)` for `: Bool` declarations | **DONE** |
 | T-02 | Same `enforce_input_type_ann()` helper covers public declarations | **DONE** |
 | T-03 | Added `type_compatible` check + `AnnotationMismatch` error in array Bool path | **DONE** |
-| T-04 | Validate annotation shape matches value shape in `lower_let` | **OPEN** |
-| T-05 | Add `set_type(v, IrType::Field)` in `pow_by_squaring` | **OPEN** |
-| T-06 | Preserve `Bool` type when widening to `Field[N]` annotation | **OPEN** |
+| T-04 | `TypeMismatch` error for scalar annotation on array / array annotation on scalar | **DONE** |
+| T-05 | `set_type(v, IrType::Field)` in `pow_by_squaring` + `lower_binop` Pow `exp==0` path | **DONE** |
+| T-06 | `Field[N]` loop skips elements already typed as `Bool` | **DONE** |

--- a/docs/src/content/docs/language/types-and-values.mdx
+++ b/docs/src/content/docs/language/types-and-values.mdx
@@ -29,7 +29,7 @@ let y = -7
 let big = 100000000000
 ```
 
-If an arithmetic operation overflows the i60 range, the result is automatically promoted to a `FieldElement` on the heap.
+If an arithmetic operation overflows the i60 range, a runtime error is raised. Use `field()` to convert explicitly when you need modular field arithmetic.
 
 ## Booleans
 
@@ -74,6 +74,8 @@ let sum = a + b
 let prod = a * b
 let inv = field(1) / a           // modular inverse
 ```
+
+Int and Field cannot be mixed in arithmetic. `field(3) + 5` is a runtime error — use `field(3) + field(5)` instead.
 
 Field elements are essential for circuit programming — all circuit values are field elements under the hood.
 

--- a/docs/src/content/docs/zk-concepts/field-elements.mdx
+++ b/docs/src/content/docs/zk-concepts/field-elements.mdx
@@ -3,4 +3,70 @@ title: "Field Elements"
 description: "BN254 scalar field arithmetic."
 ---
 
-Content coming soon.
+A **field element** is a number in the BN254 scalar field — integers modulo the prime:
+
+```
+p = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+```
+
+All arithmetic on field elements is **modular**: addition, subtraction, and multiplication wrap around at `p`, and division computes the modular inverse.
+
+## Int vs Field
+
+| | Int | Field |
+|---|---|---|
+| Range | -2^59 to 2^59-1 | 0 to p-1 |
+| Overflow | Runtime error | Wraps modulo p |
+| Negation | `-x` | `p - x` |
+| Division | Truncating (`7 / 2 = 3`) | Modular inverse (`1/2 = (p+1)/2`) |
+| Storage | Inline (60-bit tagged) | Heap-allocated (256-bit Montgomery) |
+
+Int and Field are **distinct types**. Mixing them in arithmetic is a runtime error:
+
+```
+field(3) + 5       // Error: Cannot mix Int and Field
+field(3) + field(5) // OK: field(8)
+```
+
+## Creating Field Elements
+
+Use the `field()` builtin to create field elements explicitly:
+
+```
+let a = field(42)          // from integer
+let b = field("0xFF")      // from hex string
+let c = field("12345")     // from decimal string
+```
+
+## Arithmetic
+
+Field elements support `+`, `-`, `*`, `/`, `^`, and `==`:
+
+```
+let a = field(10)
+let b = field(3)
+
+let sum  = a + b        // field(13)
+let diff = a - b        // field(7)
+let prod = a * b        // field(30)
+let quot = a / b        // modular inverse of 3, times 10
+let pow  = a ^ 5        // 10^5 mod p
+
+// Negative exponents compute modular inverse
+let inv = a ^ -1        // same as field(1) / a
+```
+
+## In Circuits
+
+In circuit mode (`prove {}` blocks and `circuit` CLI), **all values are field elements** implicitly. Integer variables captured by a `prove {}` block are converted to field elements automatically:
+
+```
+let x = 42
+prove {
+    // x is automatically converted to field(42) inside the circuit
+    public x
+    assert_eq(x, 42)
+}
+```
+
+This is the only place where Int→Field conversion happens implicitly. In regular VM execution, the conversion must always be explicit via `field()`.

--- a/test/vm/errors/integer_overflow.ach
+++ b/test/vm/errors/integer_overflow.ach
@@ -1,0 +1,2 @@
+// Expected error: integer overflow
+let x = 576460752303423487 + 1

--- a/test/vm/integration/stress.ach
+++ b/test/vm/integration/stress.ach
@@ -86,7 +86,7 @@ while si < 100 {
 // Sum of squares 0..99 = 99 * 100 * 199 / 6 = 328350
 assert(sq_sum == 328350)
 
-// --- Power computation with integer overflow → field promotion ---
+// --- Large power computation (within i60 range) ---
 let big_pow = 2 ^ 50
 assert(big_pow == 1125899906842624)
 

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -8,6 +8,7 @@ pub enum RuntimeError {
     FunctionNotFound,
     InvalidOperand,
     DivisionByZero,
+    IntegerOverflow,
     TypeMismatch(String),
     ArityMismatch(String),
     AssertionFailed,

--- a/vm/tests/int_tests.rs
+++ b/vm/tests/int_tests.rs
@@ -1,4 +1,5 @@
-use memory::{Function, Value};
+use memory::{Function, Value, I60_MAX, I60_MIN};
+use vm::error::RuntimeError;
 use vm::opcode::{instruction::*, OpCode};
 use vm::{CallFrame, VM};
 
@@ -29,6 +30,32 @@ fn run_simple(chunk: Vec<u32>, constants: Vec<Value>) -> VM {
     vm
 }
 
+fn run_fallible(chunk: Vec<u32>, constants: Vec<Value>) -> Result<VM, RuntimeError> {
+    let mut vm = VM::new();
+    let func = Function {
+        name: "test".to_string(),
+        arity: 0,
+        max_slots: 255,
+        chunk,
+        constants,
+        upvalue_info: Vec::new(),
+    };
+    let func_idx = vm.heap.alloc_function(func);
+    let closure = memory::Closure {
+        function: func_idx,
+        upvalues: Vec::new(),
+    };
+    let closure_idx = vm.heap.alloc_closure(closure);
+
+    vm.frames.push(CallFrame {
+        closure: closure_idx,
+        ip: 0,
+        base: 0,
+        dest_reg: 0,
+    });
+    vm.interpret().map(|_| vm)
+}
+
 #[test]
 fn test_int_storage() {
     let val = Value::int(50);
@@ -40,21 +67,131 @@ fn test_int_storage() {
 }
 
 #[test]
-fn test_int_addition_overflow_promotes_to_field() {
-    // Large values that overflow i60 should promote to Field
+fn test_int_addition_overflow_errors() {
     let chunk = vec![
         encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
         encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
         encode_abc(OpCode::Add.as_u8(), 2, 0, 1),
         encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
     ];
-    let max_i60: i64 = (1i64 << 59) - 1;
-    let constants = vec![Value::int(max_i60), Value::int(1)];
-    let vm = run_simple(chunk, constants);
+    let constants = vec![Value::int(I60_MAX), Value::int(1)];
+    let result = run_fallible(chunk, constants);
+    assert!(matches!(result, Err(RuntimeError::IntegerOverflow)));
+}
 
-    let res = vm.stack[2];
-    // Overflow promotes to Field
-    assert!(res.is_field());
+#[test]
+fn test_int_subtraction_overflow_errors() {
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Sub.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(I60_MIN), Value::int(1)];
+    let result = run_fallible(chunk, constants);
+    assert!(matches!(result, Err(RuntimeError::IntegerOverflow)));
+}
+
+#[test]
+fn test_int_multiplication_overflow_errors() {
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Mul.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(I60_MAX), Value::int(2)];
+    let result = run_fallible(chunk, constants);
+    assert!(matches!(result, Err(RuntimeError::IntegerOverflow)));
+}
+
+#[test]
+fn test_neg_i60_min_overflow_errors() {
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abc(OpCode::Neg.as_u8(), 1, 0, 0),
+        encode_abc(OpCode::Return.as_u8(), 1, 0, 0),
+    ];
+    let constants = vec![Value::int(I60_MIN)];
+    let result = run_fallible(chunk, constants);
+    assert!(matches!(result, Err(RuntimeError::IntegerOverflow)));
+}
+
+#[test]
+fn test_pow_negative_exponent_errors() {
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Pow.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(2), Value::int(-3)];
+    let result = run_fallible(chunk, constants);
+    assert!(matches!(result, Err(RuntimeError::TypeMismatch(_))));
+}
+
+#[test]
+fn test_pow_large_exponent_overflow_errors() {
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Pow.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(2), Value::int(100)];
+    let result = run_fallible(chunk, constants);
+    assert!(matches!(result, Err(RuntimeError::IntegerOverflow)));
+}
+
+#[test]
+fn test_pow_trivial_bases_large_exponent_ok() {
+    // 1 ^ 1000 = 1
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Pow.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(1), Value::int(1000)];
+    let vm = run_simple(chunk, constants);
+    assert!(vm.stack[2].is_int());
+    assert_eq!(vm.stack[2].as_int(), Some(1));
+
+    // 0 ^ 1000 = 0
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Pow.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(0), Value::int(1000)];
+    let vm = run_simple(chunk, constants);
+    assert!(vm.stack[2].is_int());
+    assert_eq!(vm.stack[2].as_int(), Some(0));
+
+    // (-1) ^ 1000 = 1
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Pow.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(-1), Value::int(1000)];
+    let vm = run_simple(chunk, constants);
+    assert!(vm.stack[2].is_int());
+    assert_eq!(vm.stack[2].as_int(), Some(1));
+
+    // (-1) ^ 999 = -1
+    let chunk = vec![
+        encode_abx(OpCode::LoadConst.as_u8(), 0, 0),
+        encode_abx(OpCode::LoadConst.as_u8(), 1, 1),
+        encode_abc(OpCode::Pow.as_u8(), 2, 0, 1),
+        encode_abc(OpCode::Return.as_u8(), 2, 0, 0),
+    ];
+    let constants = vec![Value::int(-1), Value::int(999)];
+    let vm = run_simple(chunk, constants);
+    assert!(vm.stack[2].is_int());
+    assert_eq!(vm.stack[2].as_int(), Some(-1));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Int overflow → `IntegerOverflow` runtime error** instead of silent promotion to `FieldElement`. Applies to Add, Sub, Mul, Neg, and Pow.
- **Int + Field mixing → `TypeMismatch` error** in `binary_op`. Use `field()` for explicit conversion.
- **Pow trivial-base fast-paths** for `0^n`, `1^n`, `(-1)^n` — never overflow regardless of exponent. Fixes `1 ^ 1000 == 1`.
- **T-04**: Scalar annotation on array / array annotation on scalar now rejected with `TypeMismatch`.
- **T-05**: `pow_by_squaring` intermediates and `exp==0` constant now typed `IrType::Field`.
- **T-06**: `Field[N]` annotation preserves `Bool` type on elements already typed as `Bool`.
- **Docs**: Updated integer overflow semantics in types-and-values, wrote full field-elements page.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — 900+ tests pass
- [x] `bash test/run_tests.sh` — 65/65 integration tests pass
- [x] New `.ach` error test for integer overflow
- [x] 7 new Rust tests for overflow/type-mismatch/trivial-bases + 7 new IR tests for T-04/T-05/T-06