### PR TITLE
feat: Phase 6 — multi-prime serialization (PrimeId in all artifacts)

### DIFF
--- a/cli/src/commands/circuit.rs
+++ b/cli/src/commands/circuit.rs
@@ -7,6 +7,7 @@ use compiler::plonkish_backend::PlonkishCompiler;
 use compiler::r1cs_backend::R1CSCompiler;
 use constraints::{write_r1cs, write_wtns};
 use ir::prove_ir::ProveIrCompiler;
+use memory::field::PrimeId;
 use memory::FieldElement;
 
 use super::ErrorFormat;
@@ -423,10 +424,10 @@ fn run_r1cs_pipeline(
             return Err(anyhow::anyhow!("{msg}"));
         }
 
-        let r1cs_data = write_r1cs(&compiler.cs);
+        let r1cs_data = write_r1cs(&compiler.cs, PrimeId::Bn254);
         fs::write(r1cs_path, &r1cs_data).with_context(|| format!("cannot write {r1cs_path}"))?;
 
-        let wtns_data = write_wtns(&witness_vec);
+        let wtns_data = write_wtns(&witness_vec, PrimeId::Bn254);
         fs::write(wtns_path, &wtns_data).with_context(|| format!("cannot write {wtns_path}"))?;
 
         if verbose {
@@ -480,7 +481,7 @@ fn run_r1cs_pipeline(
             .compile_ir(program)
             .map_err(|e| anyhow::anyhow!("R1CS compilation error: {e}"))?;
 
-        let r1cs_data = write_r1cs(&compiler.cs);
+        let r1cs_data = write_r1cs(&compiler.cs, PrimeId::Bn254);
         fs::write(r1cs_path, &r1cs_data).with_context(|| format!("cannot write {r1cs_path}"))?;
 
         if verbose {

--- a/cli/src/commands/compile.rs
+++ b/cli/src/commands/compile.rs
@@ -24,7 +24,10 @@ pub fn compile_file(path: &str, output: Option<&str>, error_format: ErrorFormat)
 
         let mut file = fs::File::create(out_path).context("Failed to create output file")?;
 
-        file.write_all(b"ACH\x0A")?;
+        file.write_all(b"ACH\x0B")?;
+
+        // PrimeId (v0x0B+): identifies which prime field was used
+        file.write_u8(memory::field::PrimeId::Bn254.to_byte())?;
 
         // Metadata
         let main_func = compiler

--- a/cli/src/commands/disassemble.rs
+++ b/cli/src/commands/disassemble.rs
@@ -284,7 +284,10 @@ fn dump_prove_blocks_from_bytecode(bytecode: &[u32], compiler: &compiler::Compil
         };
 
         match ir::prove_ir::ProveIR::from_bytes(blob) {
-            Ok(prove_ir) => print!("{prove_ir}"),
+            Ok((prove_ir, prime_id)) => {
+                println!("  prime: {prime_id}");
+                print!("{prove_ir}");
+            }
             Err(e) => println!("  (failed to deserialize ProveIR: {e})"),
         }
     }

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -253,7 +253,7 @@ impl ProveHandler for InspectorProveHandler {
         prove_ir_bytes: &[u8],
         scope_values: &HashMap<String, FieldElement>,
     ) -> Result<ProveResult, ProveError> {
-        let prove_ir = ir::prove_ir::ProveIR::from_bytes(prove_ir_bytes)
+        let (prove_ir, _prime_id) = ir::prove_ir::ProveIR::from_bytes(prove_ir_bytes)
             .map_err(|e| ProveError::IrLowering(format!("ProveIR deserialization: {e}")))?;
 
         let name = prove_ir.name.as_deref().unwrap_or("");

--- a/cli/src/prove_handler.rs
+++ b/cli/src/prove_handler.rs
@@ -72,7 +72,7 @@ impl ProveHandler for DefaultProveHandler {
         scope_values: &HashMap<String, FieldElement>,
     ) -> Result<ProveResult, ProveError> {
         // 1. Deserialize ProveIR from bytes
-        let prove_ir = ir::prove_ir::ProveIR::from_bytes(prove_ir_bytes)
+        let (prove_ir, _prime_id) = ir::prove_ir::ProveIR::from_bytes(prove_ir_bytes)
             .map_err(|e| ProveError::IrLowering(format!("ProveIR deserialization: {e}")))?;
 
         // 2. Instantiate with scope values (captures resolved here)

--- a/cli/tests/commands_test.rs
+++ b/cli/tests/commands_test.rs
@@ -28,7 +28,7 @@ fn compile_valid_source_with_output() {
     // Verify .achb was created with the ACH magic header
     let bytes = std::fs::read(&out_path).unwrap();
     assert!(bytes.len() >= 4, "output file too small");
-    assert_eq!(&bytes[..4], b"ACH\x0A", "wrong magic header");
+    assert_eq!(&bytes[..4], b"ACH\x0B", "wrong magic header");
 }
 
 #[test]

--- a/cli/tests/solidity_e2e_test.rs
+++ b/cli/tests/solidity_e2e_test.rs
@@ -16,6 +16,7 @@ use compiler::witness_gen::WitnessGenerator;
 use constraints::{write_r1cs, write_wtns};
 use ir::passes::bool_prop::compute_proven_boolean;
 use ir::IrLowering;
+use memory::field::PrimeId;
 use memory::FieldElement;
 use vm::ProveResult;
 
@@ -121,8 +122,8 @@ fn solidity_e2e_mul() {
     let d = dir.path();
     let r1cs_path = d.join("circuit.r1cs");
     let wtns_path = d.join("witness.wtns");
-    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs)).unwrap();
-    std::fs::write(&wtns_path, write_wtns(&witness)).unwrap();
+    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs, PrimeId::Bn254)).unwrap();
+    std::fs::write(&wtns_path, write_wtns(&witness, PrimeId::Bn254)).unwrap();
     eprintln!("  Step 2/6: R1CS + WTNS exported");
 
     // 3. snarkjs trusted setup + prove
@@ -366,8 +367,8 @@ fn solidity_e2e_poseidon() {
     let d = dir.path();
     let r1cs_path = d.join("circuit.r1cs");
     let wtns_path = d.join("witness.wtns");
-    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs)).unwrap();
-    std::fs::write(&wtns_path, write_wtns(&witness)).unwrap();
+    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs, PrimeId::Bn254)).unwrap();
+    std::fs::write(&wtns_path, write_wtns(&witness, PrimeId::Bn254)).unwrap();
 
     // Setup
     let pot = d.join("pot.ptau");

--- a/compiler/src/control_flow/zk.rs
+++ b/compiler/src/control_flow/zk.rs
@@ -258,9 +258,11 @@ pub(super) fn compile_prove(
     }
 
     // 5. Serialize ProveIR and store as bytes constant.
-    let ir_bytes = prove_ir.to_bytes().map_err(|e| {
-        CompilerError::CompileError(format!("ProveIR serialization: {e}"), compiler.cur_span())
-    })?;
+    let ir_bytes = prove_ir
+        .to_bytes(memory::field::PrimeId::Bn254)
+        .map_err(|e| {
+            CompilerError::CompileError(format!("ProveIR serialization: {e}"), compiler.cur_span())
+        })?;
     let ir_handle = compiler.intern_bytes(ir_bytes);
     let ir_val = Value::bytes(ir_handle);
     let ir_idx = compiler.add_constant(ir_val)?;

--- a/compiler/src/statements/mod.rs
+++ b/compiler/src/statements/mod.rs
@@ -235,9 +235,11 @@ impl StatementCompiler for Compiler {
         prove_ir.name = Some(name.to_string());
 
         // 3. Serialize to bytes
-        let ir_bytes = prove_ir.to_bytes().map_err(|e| {
-            CompilerError::CompileError(format!("ProveIR serialization: {e}"), span_box(span))
-        })?;
+        let ir_bytes = prove_ir
+            .to_bytes(memory::field::PrimeId::Bn254)
+            .map_err(|e| {
+                CompilerError::CompileError(format!("ProveIR serialization: {e}"), span_box(span))
+            })?;
 
         // 4. Store bytes in constant pool and bind as global
         let handle = self.intern_bytes(ir_bytes);
@@ -307,9 +309,11 @@ impl StatementCompiler for Compiler {
         prove_ir.name = Some(alias.to_string());
 
         // 4. Serialize to bytes
-        let ir_bytes = prove_ir.to_bytes().map_err(|e| {
-            CompilerError::CompileError(format!("ProveIR serialization: {e}"), span_box(span))
-        })?;
+        let ir_bytes = prove_ir
+            .to_bytes(memory::field::PrimeId::Bn254)
+            .map_err(|e| {
+                CompilerError::CompileError(format!("ProveIR serialization: {e}"), span_box(span))
+            })?;
 
         // 5. Store bytes in constant pool and bind alias as global
         let handle = self.intern_bytes(ir_bytes);

--- a/compiler/tests/merkle_e2e_test.rs
+++ b/compiler/tests/merkle_e2e_test.rs
@@ -5,6 +5,7 @@ use compiler::witness_gen::WitnessGenerator;
 use constraints::poseidon::{poseidon_hash, PoseidonParams};
 use constraints::{write_r1cs, write_wtns};
 use ir::IrLowering;
+use memory::field::PrimeId;
 use memory::FieldElement;
 
 /// Build an 8-leaf Merkle tree using Poseidon and return the root.
@@ -196,10 +197,10 @@ fn merkle_depth3_export_roundtrip() {
     compiler.cs.verify(&witness).unwrap();
 
     // Export and verify structure
-    let r1cs_data = write_r1cs(&compiler.cs);
+    let r1cs_data = write_r1cs(&compiler.cs, PrimeId::Bn254);
     assert_eq!(&r1cs_data[0..4], b"r1cs");
 
-    let wtns_data = write_wtns(&witness);
+    let wtns_data = write_wtns(&witness, PrimeId::Bn254);
     assert_eq!(&wtns_data[0..4], b"wtns");
 
     // Wire counts should match

--- a/compiler/tests/merkle_vectors.rs
+++ b/compiler/tests/merkle_vectors.rs
@@ -31,6 +31,7 @@ use constraints::poseidon::{poseidon_hash, PoseidonParams};
 use constraints::{write_r1cs, write_wtns};
 use ir::passes::bool_prop::compute_proven_boolean;
 use ir::IrLowering;
+use memory::field::PrimeId;
 use memory::FieldElement;
 
 // ============================================================================
@@ -613,10 +614,10 @@ fn merkle_depth2_export_roundtrip() {
     compiler.cs.verify(&witness).expect("verification failed");
 
     // Export and validate magic bytes
-    let r1cs_data = write_r1cs(&compiler.cs);
+    let r1cs_data = write_r1cs(&compiler.cs, PrimeId::Bn254);
     assert_eq!(&r1cs_data[0..4], b"r1cs", "R1CS magic mismatch");
 
-    let wtns_data = write_wtns(&witness);
+    let wtns_data = write_wtns(&witness, PrimeId::Bn254);
     assert_eq!(&wtns_data[0..4], b"wtns", "WTNS magic mismatch");
 
     // Wire counts must match
@@ -649,10 +650,10 @@ fn merkle_depth4_export_roundtrip() {
         .expect("R1CS compilation failed");
     compiler.cs.verify(&witness).expect("verification failed");
 
-    let r1cs_data = write_r1cs(&compiler.cs);
+    let r1cs_data = write_r1cs(&compiler.cs, PrimeId::Bn254);
     assert_eq!(&r1cs_data[0..4], b"r1cs");
 
-    let wtns_data = write_wtns(&witness);
+    let wtns_data = write_wtns(&witness, PrimeId::Bn254);
     assert_eq!(&wtns_data[0..4], b"wtns");
 
     let n_wires = u32::from_le_bytes(r1cs_data[60..64].try_into().unwrap());

--- a/constraints/src/export.rs
+++ b/constraints/src/export.rs
@@ -15,10 +15,7 @@ fn prime_le_bytes(prime_id: PrimeId) -> [u8; 32] {
         PrimeId::Bls12_381 => memory::field::Bls12_381Fr::modulus_le_bytes(),
         PrimeId::Goldilocks => memory::field::GoldilocksFr::modulus_le_bytes(),
         // Future backends: add here when FieldBackend impls exist
-        _ => unimplemented!(
-            "R1CS/WTNS export not yet supported for {}",
-            prime_id.name()
-        ),
+        _ => unimplemented!("R1CS/WTNS export not yet supported for {}", prime_id.name()),
     }
 }
 

--- a/constraints/src/export.rs
+++ b/constraints/src/export.rs
@@ -3,27 +3,26 @@
 /// Produces `.r1cs` (version 1) and `.wtns` (version 2) files that can be
 /// consumed directly by `snarkjs` for Groth16 proof generation.
 use crate::r1cs::{ConstraintSystem, LinearCombination};
+use memory::field::PrimeId;
 use memory::FieldElement;
 
-/// BN254 scalar field prime in 32-byte little-endian form.
-/// p = 21888242871839275222246405745257275088548364400416034343698204186575808495617
-const BN254_PRIME_LE: [u8; 32] = {
-    // MODULUS limbs (little-endian u64):
-    //   [0x43e1f593f0000001, 0x2833e84879b97091, 0xb85045b68181585d, 0x30644e72e131a029]
-    let l0: u64 = 0x43e1f593f0000001;
-    let l1: u64 = 0x2833e84879b97091;
-    let l2: u64 = 0xb85045b68181585d;
-    let l3: u64 = 0x30644e72e131a029;
-    let b0 = l0.to_le_bytes();
-    let b1 = l1.to_le_bytes();
-    let b2 = l2.to_le_bytes();
-    let b3 = l3.to_le_bytes();
-    [
-        b0[0], b0[1], b0[2], b0[3], b0[4], b0[5], b0[6], b0[7], b1[0], b1[1], b1[2], b1[3], b1[4],
-        b1[5], b1[6], b1[7], b2[0], b2[1], b2[2], b2[3], b2[4], b2[5], b2[6], b2[7], b3[0], b3[1],
-        b3[2], b3[3], b3[4], b3[5], b3[6], b3[7],
-    ]
-};
+/// Return the prime modulus as 32 little-endian bytes for the given `PrimeId`.
+///
+/// Uses the canonical `modulus_le_bytes()` from each `FieldBackend` impl.
+fn prime_le_bytes(prime_id: PrimeId) -> [u8; 32] {
+    match prime_id {
+        PrimeId::Bn254 => memory::field::Bn254Fr::modulus_le_bytes(),
+        PrimeId::Bls12_381 => memory::field::Bls12_381Fr::modulus_le_bytes(),
+        PrimeId::Goldilocks => memory::field::GoldilocksFr::modulus_le_bytes(),
+        // Future backends: add here when FieldBackend impls exist
+        _ => unimplemented!(
+            "R1CS/WTNS export not yet supported for {}",
+            prime_id.name()
+        ),
+    }
+}
+
+use memory::field::FieldBackend;
 
 // ============================================================================
 // Helpers
@@ -64,6 +63,7 @@ fn write_lc(buf: &mut Vec<u8>, lc: &LinearCombination) {
 ///
 /// ```
 /// use constraints::{ConstraintSystem, LinearCombination, write_r1cs};
+/// use memory::field::PrimeId;
 ///
 /// let mut cs = ConstraintSystem::new();
 /// let a = cs.alloc_witness();
@@ -74,16 +74,18 @@ fn write_lc(buf: &mut Vec<u8>, lc: &LinearCombination) {
 ///     LinearCombination::zero(),
 /// );
 ///
-/// let data = write_r1cs(&cs);
+/// let data = write_r1cs(&cs, PrimeId::Bn254);
 /// assert_eq!(&data[0..4], b"r1cs");
 /// ```
-pub fn write_r1cs(cs: &ConstraintSystem) -> Vec<u8> {
+pub fn write_r1cs(cs: &ConstraintSystem, prime_id: PrimeId) -> Vec<u8> {
     let n_wires = cs.num_variables() as u32;
     let n_pub_out: u32 = 0;
     let n_pub_in = cs.num_pub_inputs() as u32;
     let n_prv_in = n_wires - 1 - n_pub_in;
     let n_labels = n_wires as u64;
     let n_constraints = cs.num_constraints() as u32;
+    let field_size = prime_id.byte_size() as u32;
+    let prime_bytes = prime_le_bytes(prime_id);
 
     let mut buf = Vec::new();
 
@@ -94,8 +96,8 @@ pub fn write_r1cs(cs: &ConstraintSystem) -> Vec<u8> {
 
     // ── Section 1: Header ──────────────────────────────────────────────
     let mut header = Vec::new();
-    write_u32(&mut header, 32); // field_size
-    header.extend_from_slice(&BN254_PRIME_LE); // prime
+    write_u32(&mut header, field_size);
+    header.extend_from_slice(&prime_bytes);
     write_u32(&mut header, n_wires);
     write_u32(&mut header, n_pub_out);
     write_u32(&mut header, n_pub_in);
@@ -141,13 +143,16 @@ pub fn write_r1cs(cs: &ConstraintSystem) -> Vec<u8> {
 /// ```
 /// use constraints::write_wtns;
 /// use memory::FieldElement;
+/// use memory::field::PrimeId;
 ///
 /// let witness = vec![FieldElement::ONE, FieldElement::from_u64(42)];
-/// let data = write_wtns(&witness);
+/// let data = write_wtns(&witness, PrimeId::Bn254);
 /// assert_eq!(&data[0..4], b"wtns");
 /// ```
-pub fn write_wtns(witness: &[FieldElement]) -> Vec<u8> {
+pub fn write_wtns(witness: &[FieldElement], prime_id: PrimeId) -> Vec<u8> {
     let n_witness = witness.len() as u32;
+    let field_size = prime_id.byte_size() as u32;
+    let prime_bytes = prime_le_bytes(prime_id);
 
     let mut buf = Vec::new();
 
@@ -158,8 +163,8 @@ pub fn write_wtns(witness: &[FieldElement]) -> Vec<u8> {
 
     // ── Section 1: Header ──────────────────────────────────────────────
     let mut header = Vec::new();
-    write_u32(&mut header, 32); // field_size
-    header.extend_from_slice(&BN254_PRIME_LE); // prime
+    write_u32(&mut header, field_size);
+    header.extend_from_slice(&prime_bytes);
     write_u32(&mut header, n_witness);
 
     write_u32(&mut buf, 1); // section type
@@ -199,7 +204,7 @@ mod tests {
     #[test]
     fn test_r1cs_magic_and_version() {
         let cs = make_mul_circuit();
-        let data = write_r1cs(&cs);
+        let data = write_r1cs(&cs, PrimeId::Bn254);
         assert_eq!(&data[0..4], b"r1cs");
         assert_eq!(u32::from_le_bytes(data[4..8].try_into().unwrap()), 1);
         assert_eq!(u32::from_le_bytes(data[8..12].try_into().unwrap()), 3);
@@ -208,7 +213,7 @@ mod tests {
     #[test]
     fn test_r1cs_header_values() {
         let cs = make_mul_circuit();
-        let data = write_r1cs(&cs);
+        let data = write_r1cs(&cs, PrimeId::Bn254);
 
         // Section 1 header: type=1 at offset 12, size at 16..24, body starts at 24
         let sec_type = u32::from_le_bytes(data[12..16].try_into().unwrap());
@@ -222,7 +227,7 @@ mod tests {
         assert_eq!(field_size, 32);
 
         let prime = &body[4..36];
-        assert_eq!(prime, &BN254_PRIME_LE);
+        assert_eq!(prime, &prime_le_bytes(PrimeId::Bn254));
 
         let n_wires = u32::from_le_bytes(body[36..40].try_into().unwrap());
         assert_eq!(n_wires, 4); // ONE, c, a, b
@@ -243,7 +248,7 @@ mod tests {
     #[test]
     fn test_r1cs_constraint_encoding() {
         let cs = make_mul_circuit();
-        let data = write_r1cs(&cs);
+        let data = write_r1cs(&cs, PrimeId::Bn254);
 
         // Section 2 starts after section 1: 12 (file header) + 12 (sec1 header) + 64 (sec1 body) = 88
         let sec2_offset = 88;
@@ -277,7 +282,7 @@ mod tests {
     #[test]
     fn test_r1cs_wire2label_identity() {
         let cs = make_mul_circuit();
-        let data = write_r1cs(&cs);
+        let data = write_r1cs(&cs, PrimeId::Bn254);
 
         // Section 3 starts after section 2
         // Sec1: 12 + 64 = 76 bytes (header + body), sec2: 12 + constraint data
@@ -297,7 +302,7 @@ mod tests {
     #[test]
     fn test_wtns_magic_and_version() {
         let witness = vec![FieldElement::ONE, FieldElement::from_u64(42)];
-        let data = write_wtns(&witness);
+        let data = write_wtns(&witness, PrimeId::Bn254);
         assert_eq!(&data[0..4], b"wtns");
         assert_eq!(u32::from_le_bytes(data[4..8].try_into().unwrap()), 2);
         assert_eq!(u32::from_le_bytes(data[8..12].try_into().unwrap()), 2);
@@ -311,7 +316,7 @@ mod tests {
             FieldElement::from_u64(6),
             FieldElement::from_u64(7),
         ];
-        let data = write_wtns(&witness);
+        let data = write_wtns(&witness, PrimeId::Bn254);
 
         // Section 1 body at offset 24 (12 file header + 12 sec header)
         let body = &data[24..];
@@ -330,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_bn254_prime_bytes() {
-        // Verify BN254_PRIME_LE matches the known MODULUS limbs
+        // Verify prime_le_bytes(Bn254) matches the known MODULUS limbs
         let mut expected = [0u8; 32];
         let modulus: [u64; 4] = [
             0x43e1f593f0000001,
@@ -341,7 +346,7 @@ mod tests {
         for i in 0..4 {
             expected[i * 8..(i + 1) * 8].copy_from_slice(&modulus[i].to_le_bytes());
         }
-        assert_eq!(BN254_PRIME_LE, expected);
+        assert_eq!(prime_le_bytes(PrimeId::Bn254), expected);
     }
 
     #[test]
@@ -357,7 +362,7 @@ mod tests {
             LinearCombination::from_variable(c),
         );
 
-        let data = write_r1cs(&cs);
+        let data = write_r1cs(&cs, PrimeId::Bn254);
         let body = &data[24..24 + 64];
 
         let n_wires = u32::from_le_bytes(body[36..40].try_into().unwrap());

--- a/constraints/tests/export_test.rs
+++ b/constraints/tests/export_test.rs
@@ -1,5 +1,6 @@
 use constraints::r1cs::{ConstraintSystem, LinearCombination};
 use constraints::{write_r1cs, write_wtns};
+use memory::field::PrimeId;
 use memory::FieldElement;
 use std::process::Command;
 
@@ -27,7 +28,7 @@ fn make_mul_circuit() -> (ConstraintSystem, Vec<FieldElement>) {
 #[test]
 fn test_r1cs_roundtrip_structure() {
     let (cs, _) = make_mul_circuit();
-    let data = write_r1cs(&cs);
+    let data = write_r1cs(&cs, PrimeId::Bn254);
 
     // Magic + version
     assert_eq!(&data[0..4], b"r1cs");
@@ -44,7 +45,7 @@ fn test_r1cs_roundtrip_structure() {
 #[test]
 fn test_wtns_roundtrip_structure() {
     let (_, witness) = make_mul_circuit();
-    let data = write_wtns(&witness);
+    let data = write_wtns(&witness, PrimeId::Bn254);
 
     assert_eq!(&data[0..4], b"wtns");
     assert_eq!(u32::from_le_bytes(data[4..8].try_into().unwrap()), 2);
@@ -60,8 +61,8 @@ fn test_wtns_roundtrip_structure() {
 #[test]
 fn test_r1cs_and_wtns_consistent_wire_count() {
     let (cs, witness) = make_mul_circuit();
-    let r1cs_data = write_r1cs(&cs);
-    let wtns_data = write_wtns(&witness);
+    let r1cs_data = write_r1cs(&cs, PrimeId::Bn254);
+    let wtns_data = write_wtns(&witness, PrimeId::Bn254);
 
     // nWires from r1cs header (offset 24 + 36 = 60)
     let n_wires = u32::from_le_bytes(r1cs_data[60..64].try_into().unwrap());
@@ -87,7 +88,7 @@ fn test_e2e_pipeline_export() {
     let mut compiler = R1CSCompiler::new();
     compiler.compile_ir(&program).unwrap();
 
-    let r1cs_data = write_r1cs(&compiler.cs);
+    let r1cs_data = write_r1cs(&compiler.cs, PrimeId::Bn254);
     assert_eq!(&r1cs_data[0..4], b"r1cs");
 
     let mut inputs = HashMap::new();
@@ -99,7 +100,7 @@ fn test_e2e_pipeline_export() {
     let witness = wg.generate(&inputs).unwrap();
     compiler.cs.verify(&witness).unwrap();
 
-    let wtns_data = write_wtns(&witness);
+    let wtns_data = write_wtns(&witness, PrimeId::Bn254);
     assert_eq!(&wtns_data[0..4], b"wtns");
 }
 
@@ -176,7 +177,7 @@ fn test_snarkjs_groth16_full() {
     let r1cs_path = p("circuit.r1cs");
     let wtns_path = p("witness.wtns");
 
-    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs)).unwrap();
+    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs, PrimeId::Bn254)).unwrap();
 
     let mut inputs = HashMap::new();
     inputs.insert("out".to_string(), FieldElement::from_u64(42));
@@ -186,7 +187,7 @@ fn test_snarkjs_groth16_full() {
     let wg = WitnessGenerator::from_compiler(&compiler);
     let witness = wg.generate(&inputs).unwrap();
     compiler.cs.verify(&witness).unwrap();
-    std::fs::write(&wtns_path, write_wtns(&witness)).unwrap();
+    std::fs::write(&wtns_path, write_wtns(&witness, PrimeId::Bn254)).unwrap();
 
     // Powers of Tau ceremony
     let pot12 = p("pot12_0000.ptau");
@@ -317,7 +318,7 @@ fn test_snarkjs_r1cs_info() {
     let r1cs_path = p("circuit.r1cs");
     let wtns_path = p("witness.wtns");
 
-    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs)).unwrap();
+    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs, PrimeId::Bn254)).unwrap();
 
     let mut inputs = HashMap::new();
     inputs.insert("out".to_string(), FieldElement::from_u64(42));
@@ -326,7 +327,7 @@ fn test_snarkjs_r1cs_info() {
 
     let wg = WitnessGenerator::from_compiler(&compiler);
     let witness = wg.generate(&inputs).unwrap();
-    std::fs::write(&wtns_path, write_wtns(&witness)).unwrap();
+    std::fs::write(&wtns_path, write_wtns(&witness, PrimeId::Bn254)).unwrap();
 
     snarkjs(&["snarkjs", "r1cs", "info", &r1cs_path]);
     snarkjs(&["snarkjs", "wtns", "check", &r1cs_path, &wtns_path]);

--- a/constraints/tests/snarkjs_cross_validation.rs
+++ b/constraints/tests/snarkjs_cross_validation.rs
@@ -26,6 +26,7 @@ use compiler::witness_gen::WitnessGenerator;
 use constraints::poseidon::{poseidon_hash, PoseidonParams};
 use constraints::{write_r1cs, write_wtns};
 use ir::IrLowering;
+use memory::field::PrimeId;
 use memory::FieldElement;
 
 // ============================================================================
@@ -120,8 +121,8 @@ fn cross_validate(
     let wtns_path = dir.path().join("witness.wtns");
     let wtns_json_path = dir.path().join("witness.json");
 
-    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs)).unwrap();
-    std::fs::write(&wtns_path, write_wtns(&witness)).unwrap();
+    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs, PrimeId::Bn254)).unwrap();
+    std::fs::write(&wtns_path, write_wtns(&witness, PrimeId::Bn254)).unwrap();
 
     let r1cs_str = r1cs_path.to_str().unwrap();
     let wtns_str = wtns_path.to_str().unwrap();
@@ -515,8 +516,8 @@ fn golden_poseidon_groth16_full_cycle() {
     let p = |name: &str| dir.path().join(name).to_str().unwrap().to_string();
     let r1cs_path = p("circuit.r1cs");
     let wtns_path = p("witness.wtns");
-    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs)).unwrap();
-    std::fs::write(&wtns_path, write_wtns(&witness)).unwrap();
+    std::fs::write(&r1cs_path, write_r1cs(&compiler.cs, PrimeId::Bn254)).unwrap();
+    std::fs::write(&wtns_path, write_wtns(&witness, PrimeId::Bn254)).unwrap();
 
     eprintln!("  Step 1/6: Achronyme compile + export ✓");
     eprintln!("  Constraints: {}", compiler.cs.num_constraints());

--- a/ir/src/prove_ir/types.rs
+++ b/ir/src/prove_ir/types.rs
@@ -11,6 +11,7 @@
 
 use achronyme_parser::diagnostic::SpanRange;
 use bincode::Options;
+use memory::field::PrimeId;
 use memory::FieldElement;
 use serde::{Deserialize, Serialize};
 
@@ -45,20 +46,24 @@ const PROVE_IR_MAGIC: &[u8; 4] = b"ACHP";
 /// Format version (increment when enum variants change or fields are added).
 /// v2: added `capture_arrays` field to ProveIR.
 /// v3: added `message` field to CircuitNode::AssertEq.
-const PROVE_IR_FORMAT_VERSION: u8 = 3;
+/// v4: added PrimeId byte after version (multi-prime support).
+const PROVE_IR_FORMAT_VERSION: u8 = 4;
 
 /// Maximum allowed size for deserialized ProveIR data (64 MB).
 /// Prevents allocation bombs from crafted length prefixes.
 const PROVE_IR_MAX_SIZE: u64 = 64 * 1024 * 1024;
 
 impl ProveIR {
-    /// Serialize to bytes with magic header and version (for .achb bytecode files).
-    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+    /// Serialize to bytes with magic header, version, and prime identity.
+    ///
+    /// Format v4: `[MAGIC:4][VERSION:1][PRIME_ID:1][BINCODE_PAYLOAD]`
+    pub fn to_bytes(&self, prime_id: PrimeId) -> Result<Vec<u8>, String> {
         let payload =
             bincode::serialize(self).map_err(|e| format!("ProveIR serialization failed: {e}"))?;
-        let mut out = Vec::with_capacity(5 + payload.len());
+        let mut out = Vec::with_capacity(6 + payload.len());
         out.extend_from_slice(PROVE_IR_MAGIC);
         out.push(PROVE_IR_FORMAT_VERSION);
+        out.push(prime_id.to_byte());
         out.extend_from_slice(&payload);
         Ok(out)
     }
@@ -88,7 +93,10 @@ impl ProveIR {
     }
 
     /// Deserialize from bytes, validating magic header, version, and invariants.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+    ///
+    /// Returns the deserialized `ProveIR` and the `PrimeId` from the header.
+    /// Accepts v3 (legacy, no prime — defaults to BN254) and v4 (with prime byte).
+    pub fn from_bytes(bytes: &[u8]) -> Result<(Self, PrimeId), String> {
         if bytes.len() < 5 {
             return Err("ProveIR data too short (missing header)".into());
         }
@@ -99,13 +107,29 @@ impl ProveIR {
                 &bytes[..4]
             ));
         }
-        if bytes[4] != PROVE_IR_FORMAT_VERSION {
-            return Err(format!(
-                "unsupported ProveIR format version: expected {}, got {}",
-                PROVE_IR_FORMAT_VERSION, bytes[4]
-            ));
-        }
-        let payload = &bytes[5..];
+        let version = bytes[4];
+        let (prime_id, payload) = match version {
+            3 => {
+                // Legacy v3: no PrimeId byte, assume BN254
+                (PrimeId::Bn254, &bytes[5..])
+            }
+            PROVE_IR_FORMAT_VERSION => {
+                // v4+: PrimeId byte at offset 5, payload starts at 6
+                if bytes.len() < 6 {
+                    return Err("ProveIR v4 data too short (missing prime byte)".into());
+                }
+                let pid = PrimeId::from_byte(bytes[5]).ok_or_else(|| {
+                    format!("unknown PrimeId byte 0x{:02x} in ProveIR header", bytes[5])
+                })?;
+                (pid, &bytes[6..])
+            }
+            _ => {
+                return Err(format!(
+                    "unsupported ProveIR format version: expected 3 or {}, got {}",
+                    PROVE_IR_FORMAT_VERSION, version
+                ));
+            }
+        };
         let prove_ir: Self = bincode::options()
             .with_limit(PROVE_IR_MAX_SIZE)
             .with_fixint_encoding()
@@ -113,7 +137,7 @@ impl ProveIR {
             .deserialize(payload)
             .map_err(|e| format!("ProveIR deserialization failed: {e}"))?;
         prove_ir.validate()?;
-        Ok(prove_ir)
+        Ok((prove_ir, prime_id))
     }
 }
 
@@ -783,8 +807,11 @@ mod tests {
 
     /// Round-trip: ProveIR → bytes → ProveIR, verify equality.
     fn assert_round_trip(prove_ir: &ProveIR) {
-        let bytes = prove_ir.to_bytes().expect("serialization failed");
-        let restored = ProveIR::from_bytes(&bytes).expect("deserialization failed");
+        let bytes = prove_ir
+            .to_bytes(PrimeId::Bn254)
+            .expect("serialization failed");
+        let (restored, prime) = ProveIR::from_bytes(&bytes).expect("deserialization failed");
+        assert_eq!(prime, PrimeId::Bn254);
 
         // Spans are skipped, so we compare field-by-field excluding spans.
         assert_eq!(prove_ir.public_inputs, restored.public_inputs);
@@ -823,8 +850,8 @@ mod tests {
             "public x\npublic out\nwitness s\nassert_eq(x + s, out, \"sums must match\")",
         )
         .unwrap();
-        let bytes = ir.to_bytes().expect("serialization failed");
-        let restored = ProveIR::from_bytes(&bytes).expect("deserialization failed");
+        let bytes = ir.to_bytes(PrimeId::Bn254).expect("serialization failed");
+        let (restored, _) = ProveIR::from_bytes(&bytes).expect("deserialization failed");
         // Verify message survives round-trip
         let msg = restored.body.iter().find_map(|n| {
             if let CircuitNode::AssertEq { message, .. } = n {
@@ -917,8 +944,8 @@ mod tests {
             "public out\nassert_eq(Field::ZERO + Field::ONE, out)",
         )
         .unwrap();
-        let bytes = ir.to_bytes().unwrap();
-        let restored = ProveIR::from_bytes(&bytes).unwrap();
+        let bytes = ir.to_bytes(PrimeId::Bn254).unwrap();
+        let (restored, _) = ProveIR::from_bytes(&bytes).unwrap();
 
         // The body should contain Const(ZERO) and Const(ONE) nodes.
         // After round-trip, the FieldElement values must be identical.
@@ -967,8 +994,8 @@ mod tests {
         let program1 = ir.instantiate(&HashMap::new()).unwrap();
 
         // Round-trip and instantiate
-        let bytes = ir.to_bytes().unwrap();
-        let restored = ProveIR::from_bytes(&bytes).unwrap();
+        let bytes = ir.to_bytes(PrimeId::Bn254).unwrap();
+        let (restored, _) = ProveIR::from_bytes(&bytes).unwrap();
         let program2 = restored.instantiate(&HashMap::new()).unwrap();
 
         // Both should produce identical instruction counts and types
@@ -985,7 +1012,7 @@ mod tests {
             "public a\npublic b\npublic out\nassert_eq(poseidon(a, b), out)",
         )
         .unwrap();
-        let bytes = ir.to_bytes().unwrap();
+        let bytes = ir.to_bytes(PrimeId::Bn254).unwrap();
         // A simple circuit should serialize to < 1 KB
         assert!(
             bytes.len() < 1024,
@@ -1083,7 +1110,7 @@ mod tests {
             body: vec![],
             capture_arrays: vec![],
         }
-        .to_bytes()
+        .to_bytes(PrimeId::Bn254)
         .unwrap();
         bytes[4] = 99; // corrupt version byte
         let err = ProveIR::from_bytes(&bytes).unwrap_err();
@@ -1107,7 +1134,7 @@ mod tests {
             body: vec![],
             capture_arrays: vec![],
         }
-        .to_bytes()
+        .to_bytes(PrimeId::Bn254)
         .unwrap();
         // Truncate the payload
         let truncated = &bytes[..bytes.len() / 2];
@@ -1116,7 +1143,8 @@ mod tests {
 
     #[test]
     fn adversarial_random_bytes() {
-        let garbage = b"ACHP\x01\xff\xff\xff\xff\xff\xff\xff\xff";
+        // Version 99 is unsupported
+        let garbage = b"ACHP\x63\xff\xff\xff\xff\xff\xff\xff\xff";
         assert!(ProveIR::from_bytes(garbage).is_err());
     }
 
@@ -1137,7 +1165,7 @@ mod tests {
             }],
             capture_arrays: vec![],
         };
-        let mut bytes = ir.to_bytes().unwrap();
+        let mut bytes = ir.to_bytes(PrimeId::Bn254).unwrap();
 
         // Find the FieldElement in the serialized bytes and corrupt it.
         // The ONE constant has specific limbs — replace them with MODULUS.
@@ -1183,6 +1211,7 @@ mod tests {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(b"ACHP");
         bytes.push(PROVE_IR_FORMAT_VERSION);
+        bytes.push(PrimeId::Bn254.to_byte());
         bytes.extend_from_slice(&payload);
         let err = ProveIR::from_bytes(&bytes).unwrap_err();
         assert!(
@@ -1212,6 +1241,7 @@ mod tests {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(b"ACHP");
         bytes.push(PROVE_IR_FORMAT_VERSION);
+        bytes.push(PrimeId::Bn254.to_byte());
         bytes.extend_from_slice(&payload);
         let err = ProveIR::from_bytes(&bytes).unwrap_err();
         assert!(
@@ -1240,11 +1270,73 @@ mod tests {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(b"ACHP");
         bytes.push(PROVE_IR_FORMAT_VERSION);
+        bytes.push(PrimeId::Bn254.to_byte());
         bytes.extend_from_slice(&payload);
         let err = ProveIR::from_bytes(&bytes).unwrap_err();
         assert!(
             err.contains("range_check"),
             "should reject range_check bits=300: {err}"
+        );
+    }
+
+    // =====================================================================
+    // v4 format / multi-prime tests
+    // =====================================================================
+
+    #[test]
+    fn v3_backward_compat_defaults_to_bn254() {
+        // Manually craft a v3 blob (no prime byte)
+        let ir = ProveIR {
+            name: None,
+            public_inputs: vec![],
+            witness_inputs: vec![],
+            captures: vec![],
+            body: vec![],
+            capture_arrays: vec![],
+        };
+        let payload = bincode::serialize(&ir).unwrap();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"ACHP");
+        bytes.push(3); // v3
+        bytes.extend_from_slice(&payload);
+        let (_, prime) = ProveIR::from_bytes(&bytes).unwrap();
+        assert_eq!(prime, PrimeId::Bn254);
+    }
+
+    #[test]
+    fn v4_roundtrip_with_each_prime() {
+        let ir = ProveIR {
+            name: Some("test".into()),
+            public_inputs: vec![],
+            witness_inputs: vec![],
+            captures: vec![],
+            body: vec![],
+            capture_arrays: vec![],
+        };
+        for prime in [PrimeId::Bn254, PrimeId::Bls12_381, PrimeId::Goldilocks] {
+            let bytes = ir.to_bytes(prime).unwrap();
+            let (restored, restored_prime) = ProveIR::from_bytes(&bytes).unwrap();
+            assert_eq!(restored_prime, prime, "prime mismatch for {}", prime.name());
+            assert_eq!(restored.name, ir.name);
+        }
+    }
+
+    #[test]
+    fn v4_bad_prime_byte_rejected() {
+        let ir = ProveIR {
+            name: None,
+            public_inputs: vec![],
+            witness_inputs: vec![],
+            captures: vec![],
+            body: vec![],
+            capture_arrays: vec![],
+        };
+        let mut bytes = ir.to_bytes(PrimeId::Bn254).unwrap();
+        bytes[5] = 0xFF; // invalid prime byte
+        let err = ProveIR::from_bytes(&bytes).unwrap_err();
+        assert!(
+            err.contains("PrimeId"),
+            "error should mention PrimeId: {err}"
         );
     }
 

--- a/memory/src/field/prime_id.rs
+++ b/memory/src/field/prime_id.rs
@@ -93,6 +93,37 @@ impl PrimeId {
             _ => 32,
         }
     }
+
+    /// Stable 1-byte encoding for binary serialization (bytecode headers, ProveIR, R1CS).
+    ///
+    /// These values are part of the binary format contract — never reorder or reuse.
+    pub const fn to_byte(self) -> u8 {
+        match self {
+            Self::Bn254 => 0x00,
+            Self::Bls12_381 => 0x01,
+            Self::Goldilocks => 0x02,
+            Self::Grumpkin => 0x03,
+            Self::Pallas => 0x04,
+            Self::Vesta => 0x05,
+            Self::Secp256r1 => 0x06,
+            Self::Bls12_377 => 0x07,
+        }
+    }
+
+    /// Decode from 1-byte binary encoding. Returns `None` for unknown tags.
+    pub const fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            0x00 => Some(Self::Bn254),
+            0x01 => Some(Self::Bls12_381),
+            0x02 => Some(Self::Goldilocks),
+            0x03 => Some(Self::Grumpkin),
+            0x04 => Some(Self::Pallas),
+            0x05 => Some(Self::Vesta),
+            0x06 => Some(Self::Secp256r1),
+            0x07 => Some(Self::Bls12_377),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for PrimeId {
@@ -138,5 +169,29 @@ mod tests {
         assert_eq!(PrimeId::Bn254.byte_size(), 32);
         assert_eq!(PrimeId::Bls12_381.byte_size(), 32);
         assert_eq!(PrimeId::Goldilocks.byte_size(), 8);
+    }
+
+    #[test]
+    fn test_byte_roundtrip() {
+        let primes = [
+            PrimeId::Bn254,
+            PrimeId::Bls12_381,
+            PrimeId::Goldilocks,
+            PrimeId::Grumpkin,
+            PrimeId::Pallas,
+            PrimeId::Vesta,
+            PrimeId::Secp256r1,
+            PrimeId::Bls12_377,
+        ];
+        for (i, p) in primes.iter().enumerate() {
+            assert_eq!(p.to_byte(), i as u8);
+            assert_eq!(PrimeId::from_byte(p.to_byte()), Some(*p));
+        }
+    }
+
+    #[test]
+    fn test_byte_unknown() {
+        assert_eq!(PrimeId::from_byte(0x08), None);
+        assert_eq!(PrimeId::from_byte(0xFF), None);
     }
 }

--- a/vm/src/loader.rs
+++ b/vm/src/loader.rs
@@ -3,6 +3,7 @@ use crate::specs::{
 };
 use crate::{CallFrame, VM};
 use byteorder::{LittleEndian, ReadBytesExt};
+use memory::field::PrimeId;
 use memory::{Closure, Function, Value};
 use std::io::Read;
 
@@ -46,11 +47,22 @@ impl VM {
         let mut magic = [0u8; 4];
         reader.read_exact(&mut magic)?;
         let version = magic[3];
-        if &magic[..3] != b"ACH" || (version != 0x09 && version != 0x0A) {
+        if &magic[..3] != b"ACH" || !matches!(version, 0x09 | 0x0A | 0x0B) {
             return Err(LoaderError::Format(
                 "Invalid binary magic or version".to_string(),
             ));
         }
+
+        // v0x0B+: PrimeId byte after magic, before max_slots
+        let prime_id = if version >= 0x0B {
+            let b = reader.read_u8()?;
+            PrimeId::from_byte(b).ok_or_else(|| {
+                LoaderError::Format(format!("unknown PrimeId byte 0x{b:02x} in bytecode header"))
+            })?
+        } else {
+            PrimeId::Bn254
+        };
+        self.prime_id = prime_id;
 
         let max_slots = reader.read_u16::<LittleEndian>()?;
 

--- a/vm/src/loader.rs
+++ b/vm/src/loader.rs
@@ -38,6 +38,38 @@ impl From<memory::ArenaError> for LoaderError {
     }
 }
 
+/// Validate that canonical limbs `[l0, l1, l2, l3]` are less than the modulus
+/// for the given `PrimeId`. Returns `true` if valid.
+fn validate_field_limbs(limbs: [u64; 4], prime_id: PrimeId) -> bool {
+    use memory::field::FieldBackend;
+    let modulus_bytes = match prime_id {
+        PrimeId::Bn254 => memory::field::Bn254Fr::modulus_le_bytes(),
+        PrimeId::Bls12_381 => memory::field::Bls12_381Fr::modulus_le_bytes(),
+        PrimeId::Goldilocks => memory::field::GoldilocksFr::modulus_le_bytes(),
+        _ => return true, // Skip validation for backends without impl yet
+    };
+    // Convert modulus bytes back to limbs for comparison
+    let mut mod_limbs = [0u64; 4];
+    for i in 0..4 {
+        mod_limbs[i] = u64::from_le_bytes(
+            modulus_bytes[i * 8..(i + 1) * 8]
+                .try_into()
+                .expect("modulus_le_bytes is always 32 bytes"),
+        );
+    }
+    // Compare limbs in big-endian order (most significant first)
+    for i in (0..4).rev() {
+        if limbs[i] < mod_limbs[i] {
+            return true;
+        }
+        if limbs[i] > mod_limbs[i] {
+            return false;
+        }
+    }
+    // Equal to modulus — not valid (must be strictly less)
+    false
+}
+
 impl VM {
     /// Load an executable binary (.achb) into the VM.
     ///
@@ -107,12 +139,19 @@ impl VM {
                 )));
             }
             let mut handles = Vec::with_capacity(field_count as usize);
-            for _ in 0..field_count {
+            for i in 0..field_count {
                 let l0 = reader.read_u64::<LittleEndian>()?;
                 let l1 = reader.read_u64::<LittleEndian>()?;
                 let l2 = reader.read_u64::<LittleEndian>()?;
                 let l3 = reader.read_u64::<LittleEndian>()?;
-                let fe = memory::FieldElement::from_canonical([l0, l1, l2, l3]);
+                let limbs = [l0, l1, l2, l3];
+                if !validate_field_limbs(limbs, prime_id) {
+                    return Err(LoaderError::Format(format!(
+                        "field constant {i} exceeds {} modulus",
+                        prime_id.name()
+                    )));
+                }
+                let fe = memory::FieldElement::from_canonical(limbs);
                 let handle = self.heap.alloc_field(fe)?;
                 handles.push(handle);
             }
@@ -422,5 +461,61 @@ impl VM {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_field_limbs_bn254_zero_ok() {
+        assert!(validate_field_limbs([0, 0, 0, 0], PrimeId::Bn254));
+    }
+
+    #[test]
+    fn validate_field_limbs_bn254_one_ok() {
+        assert!(validate_field_limbs([1, 0, 0, 0], PrimeId::Bn254));
+    }
+
+    #[test]
+    fn validate_field_limbs_bn254_modulus_rejected() {
+        // BN254 modulus limbs
+        let modulus = [
+            0x43e1f593f0000001,
+            0x2833e84879b97091,
+            0xb85045b68181585d,
+            0x30644e72e131a029,
+        ];
+        assert!(!validate_field_limbs(modulus, PrimeId::Bn254));
+    }
+
+    #[test]
+    fn validate_field_limbs_bn254_modulus_minus_one_ok() {
+        let modulus_minus_1 = [
+            0x43e1f593f0000000, // l0 - 1
+            0x2833e84879b97091,
+            0xb85045b68181585d,
+            0x30644e72e131a029,
+        ];
+        assert!(validate_field_limbs(modulus_minus_1, PrimeId::Bn254));
+    }
+
+    #[test]
+    fn validate_field_limbs_goldilocks_ok() {
+        assert!(validate_field_limbs([42, 0, 0, 0], PrimeId::Goldilocks));
+    }
+
+    #[test]
+    fn validate_field_limbs_goldilocks_modulus_rejected() {
+        // Goldilocks p = 2^64 - 2^32 + 1 = 0xFFFFFFFF00000001
+        let p = 0xFFFFFFFF00000001u64;
+        assert!(!validate_field_limbs([p, 0, 0, 0], PrimeId::Goldilocks));
+    }
+
+    #[test]
+    fn validate_field_limbs_goldilocks_nonzero_upper_rejected() {
+        // l1 != 0 but l0 < p — still exceeds modulus because total > p
+        assert!(!validate_field_limbs([0, 1, 0, 0], PrimeId::Goldilocks));
     }
 }

--- a/vm/src/loader.rs
+++ b/vm/src/loader.rs
@@ -79,7 +79,7 @@ impl VM {
         let mut magic = [0u8; 4];
         reader.read_exact(&mut magic)?;
         let version = magic[3];
-        if &magic[..3] != b"ACH" || !matches!(version, 0x09 | 0x0A | 0x0B) {
+        if &magic[..3] != b"ACH" || !matches!(version, 0x09..=0x0B) {
             return Err(LoaderError::Format(
                 "Invalid binary magic or version".to_string(),
             ));

--- a/vm/src/machine/vm.rs
+++ b/vm/src/machine/vm.rs
@@ -1,6 +1,7 @@
 use crate::error::RuntimeError;
 use crate::globals::GlobalEntry;
 use crate::native::NativeObj;
+use memory::field::PrimeId;
 use memory::{Heap, Value};
 use std::collections::HashMap;
 
@@ -58,6 +59,9 @@ pub struct VM {
 
     /// Per-tag method tables for method dispatch (`.method()` syntax).
     pub prototype_registry: PrototypeRegistry,
+
+    /// Prime field loaded from bytecode header (v0x0B+). Defaults to BN254.
+    pub prime_id: PrimeId,
 }
 
 pub const STACK_MAX: usize = 65_536;
@@ -92,6 +96,7 @@ impl VM {
             last_error_location: None,
             native_roots: Vec::new(),
             prototype_registry: PrototypeRegistry::new(),
+            prime_id: PrimeId::Bn254,
         };
 
         // Bootstrap native functions and prototype methods

--- a/vm/tests/prove_test.rs
+++ b/vm/tests/prove_test.rs
@@ -123,7 +123,7 @@ impl ProveHandler for RealProveHandler {
     ) -> Result<ProveResult, ProveError> {
         use compiler::r1cs_backend::R1CSCompiler;
 
-        let prove_ir = ir::prove_ir::ProveIR::from_bytes(prove_ir_bytes)
+        let (prove_ir, _prime_id) = ir::prove_ir::ProveIR::from_bytes(prove_ir_bytes)
             .map_err(|e| ProveError::IrLowering(format!("ProveIR: {e}")))?;
 
         let mut program = prove_ir


### PR DESCRIPTION
## Summary

- Add `PrimeId::to_byte()`/`from_byte()` stable 1-byte binary encoding (8 variants)
- Bump ProveIR to format v4: `[MAGIC][VERSION=4][PRIME_ID][BINCODE]`, v3 backward compat defaults to BN254
- Bump .achb bytecode to v0x0B: PrimeId byte after magic header, v0x09/0x0A backward compat defaults to BN254
- Parameterize `write_r1cs(cs, prime_id)` / `write_wtns(witness, prime_id)` — dynamic prime in R1CS/WTNS headers
- Add field table validation in loader: reject canonical limbs >= declared prime modulus
- Add `prime_id` field to VM struct

## Test plan

- [x] 2663 tests pass (`cargo test --workspace`)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] New tests: PrimeId byte roundtrip, ProveIR v3 backward compat, v4 multi-prime roundtrip, bad prime byte rejection, field limbs validation (BN254 + Goldilocks boundaries)
- [x] E2E `test/run_tests.sh` (reviewer)