### PR TITLE
feat: Phase 7 — feature-gated prover adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-bn254"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1108,7 @@ dependencies = [
 name = "proving"
 version = "0.1.0-beta.18"
 dependencies = [
+ "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",

--- a/cli/src/commands/circuit.rs
+++ b/cli/src/commands/circuit.rs
@@ -513,7 +513,7 @@ fn run_r1cs_pipeline(
     if let Some(sol_path) = solidity_path {
         let cache_dir = crate::cache_dir();
 
-        let vk = proving::groth16::setup_vk_only(&compiler.cs, &cache_dir)
+        let vk = proving::groth16_bn254::setup_vk_only(&compiler.cs, &cache_dir)
             .map_err(|e| anyhow::anyhow!("Groth16 setup failed: {e}"))?;
 
         let sol_source = proving::solidity::generate_solidity_verifier(&vk);

--- a/cli/src/prove_handler.rs
+++ b/cli/src/prove_handler.rs
@@ -156,7 +156,7 @@ impl ProveHandler for SharedProveHandler {
 
 impl VerifyHandler for DefaultProveHandler {
     fn verify_proof(&self, proof: &memory::ProofObject) -> Result<bool, String> {
-        proving::groth16::verify_proof_from_json(
+        proving::groth16_bn254::verify_proof_from_json(
             &proof.proof_json,
             &proof.public_json,
             &proof.vkey_json,
@@ -189,7 +189,7 @@ impl DefaultProveHandler {
 
         let n_constraints = r1cs.cs.num_constraints();
 
-        let result = proving::groth16::generate_proof(&r1cs.cs, &witness, &self.cache_dir)
+        let result = proving::groth16_bn254::generate_proof(&r1cs.cs, &witness, &self.cache_dir)
             .map_err(ProveError::ProofGeneration)?;
 
         if self.verbose {

--- a/cli/tests/e2e_prove_test.rs
+++ b/cli/tests/e2e_prove_test.rs
@@ -349,15 +349,21 @@ assert_eq(a * b, c)
             vkey_json,
         } => {
             // Verify the proof using the deserialization + verify roundtrip
-            let valid =
-                proving::groth16_bn254::verify_proof_from_json(&proof_json, &public_json, &vkey_json)
-                    .expect("verify_proof_from_json failed");
+            let valid = proving::groth16_bn254::verify_proof_from_json(
+                &proof_json,
+                &public_json,
+                &vkey_json,
+            )
+            .expect("verify_proof_from_json failed");
             assert!(valid, "proof should verify successfully");
 
             // Tamper with public input and verify it fails
             let tampered_public = serde_json::to_string(&vec!["99"]).unwrap();
-            let tampered_result =
-                proving::groth16_bn254::verify_proof_from_json(&proof_json, &tampered_public, &vkey_json);
+            let tampered_result = proving::groth16_bn254::verify_proof_from_json(
+                &proof_json,
+                &tampered_public,
+                &vkey_json,
+            );
             match tampered_result {
                 Ok(false) => {} // expected
                 Ok(true) => panic!("tampered proof should not verify"),
@@ -384,8 +390,9 @@ assert_eq(a * b, c)
 
     // First run: a=3, b=5, c=15
     let (compiler1, witness1) = lower_and_compile_r1cs(source, &[("a", 3), ("b", 5), ("c", 15)]);
-    let result1 = proving::groth16_bn254::generate_proof(&compiler1.cs, &witness1, cache_dir.path())
-        .expect("first generate_proof failed");
+    let result1 =
+        proving::groth16_bn254::generate_proof(&compiler1.cs, &witness1, cache_dir.path())
+            .expect("first generate_proof failed");
     assert!(matches!(result1, ProveResult::Proof { .. }));
 
     // Cache directory should now contain key files
@@ -409,8 +416,9 @@ assert_eq(a * b, c)
 
     // Second run: same circuit structure, different witness (a=2, b=9, c=18)
     let (compiler2, witness2) = lower_and_compile_r1cs(source, &[("a", 2), ("b", 9), ("c", 18)]);
-    let result2 = proving::groth16_bn254::generate_proof(&compiler2.cs, &witness2, cache_dir.path())
-        .expect("second generate_proof failed (should use cache)");
+    let result2 =
+        proving::groth16_bn254::generate_proof(&compiler2.cs, &witness2, cache_dir.path())
+            .expect("second generate_proof failed (should use cache)");
 
     match result2 {
         ProveResult::Proof { public_json, .. } => {

--- a/cli/tests/e2e_prove_test.rs
+++ b/cli/tests/e2e_prove_test.rs
@@ -95,7 +95,7 @@ assert_eq(a * b, c)
     let (compiler, witness) = lower_and_compile_r1cs(source, &[("a", 6), ("b", 7), ("c", 42)]);
 
     let cache_dir = tempfile::tempdir().unwrap();
-    let result = proving::groth16::generate_proof(&compiler.cs, &witness, cache_dir.path())
+    let result = proving::groth16_bn254::generate_proof(&compiler.cs, &witness, cache_dir.path())
         .expect("generate_proof failed");
 
     match result {
@@ -156,7 +156,7 @@ assert_eq(poseidon(a, b), h)
     );
 
     let cache_dir = tempfile::tempdir().unwrap();
-    let result = proving::groth16::generate_proof(&compiler.cs, &witness, cache_dir.path())
+    let result = proving::groth16_bn254::generate_proof(&compiler.cs, &witness, cache_dir.path())
         .expect("generate_proof failed");
 
     match result {
@@ -192,7 +192,7 @@ assert_eq(mux(flag, a, b), r)
         lower_and_compile_r1cs(source, &[("flag", 1), ("a", 10), ("b", 20), ("r", 10)]);
 
     let cache_dir = tempfile::tempdir().unwrap();
-    let result = proving::groth16::generate_proof(&compiler.cs, &witness, cache_dir.path())
+    let result = proving::groth16_bn254::generate_proof(&compiler.cs, &witness, cache_dir.path())
         .expect("generate_proof failed");
 
     match result {
@@ -339,7 +339,7 @@ assert_eq(a * b, c)
     let (compiler, witness) = lower_and_compile_r1cs(source, &[("a", 6), ("b", 7), ("c", 42)]);
 
     let cache_dir = tempfile::tempdir().unwrap();
-    let result = proving::groth16::generate_proof(&compiler.cs, &witness, cache_dir.path())
+    let result = proving::groth16_bn254::generate_proof(&compiler.cs, &witness, cache_dir.path())
         .expect("generate_proof failed");
 
     match result {
@@ -350,14 +350,14 @@ assert_eq(a * b, c)
         } => {
             // Verify the proof using the deserialization + verify roundtrip
             let valid =
-                proving::groth16::verify_proof_from_json(&proof_json, &public_json, &vkey_json)
+                proving::groth16_bn254::verify_proof_from_json(&proof_json, &public_json, &vkey_json)
                     .expect("verify_proof_from_json failed");
             assert!(valid, "proof should verify successfully");
 
             // Tamper with public input and verify it fails
             let tampered_public = serde_json::to_string(&vec!["99"]).unwrap();
             let tampered_result =
-                proving::groth16::verify_proof_from_json(&proof_json, &tampered_public, &vkey_json);
+                proving::groth16_bn254::verify_proof_from_json(&proof_json, &tampered_public, &vkey_json);
             match tampered_result {
                 Ok(false) => {} // expected
                 Ok(true) => panic!("tampered proof should not verify"),
@@ -384,7 +384,7 @@ assert_eq(a * b, c)
 
     // First run: a=3, b=5, c=15
     let (compiler1, witness1) = lower_and_compile_r1cs(source, &[("a", 3), ("b", 5), ("c", 15)]);
-    let result1 = proving::groth16::generate_proof(&compiler1.cs, &witness1, cache_dir.path())
+    let result1 = proving::groth16_bn254::generate_proof(&compiler1.cs, &witness1, cache_dir.path())
         .expect("first generate_proof failed");
     assert!(matches!(result1, ProveResult::Proof { .. }));
 
@@ -409,7 +409,7 @@ assert_eq(a * b, c)
 
     // Second run: same circuit structure, different witness (a=2, b=9, c=18)
     let (compiler2, witness2) = lower_and_compile_r1cs(source, &[("a", 2), ("b", 9), ("c", 18)]);
-    let result2 = proving::groth16::generate_proof(&compiler2.cs, &witness2, cache_dir.path())
+    let result2 = proving::groth16_bn254::generate_proof(&compiler2.cs, &witness2, cache_dir.path())
         .expect("second generate_proof failed (should use cache)");
 
     match result2 {

--- a/proving/Cargo.toml
+++ b/proving/Cargo.toml
@@ -10,6 +10,31 @@ authors.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = ["groth16-bn254", "plonk-bn254"]
+
+# Groth16 core (generic over Pairing) — activated by any groth16 variant
+groth16-core = [
+    "dep:ark-groth16",
+    "dep:ark-relations",
+    "dep:ark-std",
+    "dep:ark-serialize",
+    "dep:ark-ff",
+    "dep:ark-ec",
+    "dep:ark-snark",
+    "dep:sha2",
+    "dep:rand",
+]
+
+# Groth16 on BN254 (Ethereum-compatible, default)
+groth16-bn254 = ["groth16-core", "dep:ark-bn254"]
+
+# Groth16 on BLS12-381 (Zcash/Filecoin-compatible)
+groth16-bls12-381 = ["groth16-core", "dep:ark-bls12-381"]
+
+# PlonK/KZG on BN254 via halo2
+plonk-bn254 = ["dep:halo2_proofs", "dep:rand"]
+
 [dependencies]
 # Achronyme crates
 memory = { path = "../memory" }
@@ -20,17 +45,20 @@ vm = { path = "../vm" }
 # Serialization
 serde_json = "1"
 
-# Groth16 (ark-works ecosystem)
-ark-groth16 = "0.5"
-ark-bn254 = "0.5"
-ark-relations = "0.5"
-ark-std = "0.5"
-ark-serialize = "0.5"
-ark-ff = "0.5"
-ark-ec = "0.5"
-ark-snark = "0.5"
-sha2 = "0.10"
+# Groth16 shared (activated by groth16-core feature)
+ark-groth16 = { version = "0.5", optional = true }
+ark-relations = { version = "0.5", optional = true }
+ark-std = { version = "0.5", optional = true }
+ark-serialize = { version = "0.5", optional = true }
+ark-ff = { version = "0.5", optional = true }
+ark-ec = { version = "0.5", optional = true }
+ark-snark = { version = "0.5", optional = true }
+sha2 = { version = "0.10", optional = true }
 
-# PlonK (halo2/KZG on BN254)
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_04_20", features = ["circuit-params"] }
-rand = "0.8"
+# Curve-specific (activated by groth16-bn254 / groth16-bls12-381)
+ark-bn254 = { version = "0.5", optional = true }
+ark-bls12-381 = { version = "0.5", optional = true }
+
+# PlonK/halo2 (activated by plonk-bn254)
+halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_04_20", features = ["circuit-params"], optional = true }
+rand = { version = "0.8", optional = true }

--- a/proving/src/groth16.rs
+++ b/proving/src/groth16.rs
@@ -1,10 +1,11 @@
-//! Native Groth16 proof generation using ark-groth16.
+//! Generic Groth16 proof generation using ark-groth16.
 //!
-//! Replaces the snarkjs subprocess pipeline with in-process proving.
+//! This module is parameterized over `E: Pairing` so it works with any
+//! arkworks-compatible curve (BN254, BLS12-381, etc.). Curve-specific
+//! JSON serialization lives in dedicated modules (e.g., `groth16_bn254`).
 
 use std::path::Path;
 
-use ark_bn254::{Bn254, Fr};
 use ark_ec::pairing::Pairing;
 use ark_ff::PrimeField;
 use ark_groth16::Groth16;
@@ -13,42 +14,46 @@ use ark_relations::r1cs::{
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
-use ark_std::rand::rngs::OsRng;
+use rand::rngs::OsRng;
 use sha2::{Digest, Sha256};
 
 use constraints::r1cs::ConstraintSystem;
 use memory::FieldElement;
-use vm::ProveResult;
 
 // ============================================================================
 // Field conversion
 // ============================================================================
 
-/// Convert an Achronyme `FieldElement` (BN254 Fr) to an ark `Fr`.
-/// Both use the same modulus, so this is a lossless conversion.
-fn fe_to_ark(fe: &FieldElement) -> Fr {
-    Fr::from_le_bytes_mod_order(&fe.to_le_bytes())
+/// Convert an Achronyme `FieldElement` to an ark scalar field element.
+///
+/// Uses `from_le_bytes_mod_order` — works for any `PrimeField` regardless
+/// of modulus. The caller must ensure the source `FieldElement` was produced
+/// under the same prime; otherwise the value wraps mod the target prime.
+pub fn fe_to_ark<F: PrimeField>(fe: &FieldElement) -> F {
+    F::from_le_bytes_mod_order(&fe.to_le_bytes())
+}
+
+/// Convert an ark field element to a decimal string.
+pub fn fr_to_decimal<F: PrimeField>(f: &F) -> String {
+    f.into_bigint().to_string()
 }
 
 // ============================================================================
-// Circuit adapter
+// Circuit adapter (generic)
 // ============================================================================
 
 /// Wraps an Achronyme `ConstraintSystem` so ark-groth16 can synthesize it.
 #[derive(Clone)]
 pub struct AchronymeCircuit {
-    cs: ConstraintSystem,
-    witness: Option<Vec<FieldElement>>,
+    pub cs: ConstraintSystem,
+    pub witness: Option<Vec<FieldElement>>,
 }
 
-impl ConstraintSynthesizer<Fr> for AchronymeCircuit {
-    fn generate_constraints(self, ark_cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+impl<F: PrimeField> ConstraintSynthesizer<F> for AchronymeCircuit {
+    fn generate_constraints(self, ark_cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
         let num_pub = self.cs.num_pub_inputs();
         let num_vars = self.cs.num_variables();
 
-        // Map Achronyme variable indices to ark variables.
-        // Index 0 = ONE (implicit in ark), indices 1..=num_pub = public inputs,
-        // indices num_pub+1.. = witness variables.
         let mut var_map: Vec<ArkVariable> = Vec::with_capacity(num_vars);
 
         // Index 0 → ark's built-in ONE
@@ -59,7 +64,7 @@ impl ConstraintSynthesizer<Fr> for AchronymeCircuit {
             let val = self
                 .witness
                 .as_ref()
-                .map(|w| fe_to_ark(&w[i]))
+                .map(|w| fe_to_ark::<F>(&w[i]))
                 .unwrap_or_default();
             let v = ark_cs.new_input_variable(|| Ok(val))?;
             var_map.push(v);
@@ -70,7 +75,7 @@ impl ConstraintSynthesizer<Fr> for AchronymeCircuit {
             let val = self
                 .witness
                 .as_ref()
-                .map(|w| fe_to_ark(&w[i]))
+                .map(|w| fe_to_ark::<F>(&w[i]))
                 .unwrap_or_default();
             let v = ark_cs.new_witness_variable(|| Ok(val))?;
             var_map.push(v);
@@ -78,9 +83,9 @@ impl ConstraintSynthesizer<Fr> for AchronymeCircuit {
 
         // Convert each (A, B, C) constraint
         for constraint in self.cs.constraints() {
-            let a = convert_lc(&constraint.a, &var_map);
-            let b = convert_lc(&constraint.b, &var_map);
-            let c = convert_lc(&constraint.c, &var_map);
+            let a = convert_lc::<F>(&constraint.a, &var_map);
+            let b = convert_lc::<F>(&constraint.b, &var_map);
+            let c = convert_lc::<F>(&constraint.c, &var_map);
             ark_cs.enforce_constraint(a, b, c)?;
         }
 
@@ -89,43 +94,37 @@ impl ConstraintSynthesizer<Fr> for AchronymeCircuit {
 }
 
 /// Convert an Achronyme `LinearCombination` to an ark `LinearCombination`.
-fn convert_lc(
+fn convert_lc<F: PrimeField>(
     lc: &constraints::r1cs::LinearCombination,
     var_map: &[ArkVariable],
-) -> ark_relations::r1cs::LinearCombination<Fr> {
+) -> ark_relations::r1cs::LinearCombination<F> {
     let mut ark_lc = ark_relations::r1cs::LinearCombination::zero();
     for (var, coeff) in &lc.terms {
-        ark_lc += (fe_to_ark(coeff), var_map[var.index()]);
+        ark_lc += (fe_to_ark::<F>(coeff), var_map[var.index()]);
     }
     ark_lc
 }
 
 // ============================================================================
-// Proof generation (top-level entry point)
+// Proof generation (generic over Pairing)
 // ============================================================================
 
-/// Run trusted setup (or load cached keys) without proving.
-pub fn setup_keys(
+/// Run trusted setup (or load cached keys).
+pub fn setup_keys<E: Pairing>(
     cs: &ConstraintSystem,
     cache_dir: &Path,
-) -> Result<
-    (
-        ark_groth16::ProvingKey<Bn254>,
-        ark_groth16::VerifyingKey<Bn254>,
-    ),
-    String,
-> {
+) -> Result<(ark_groth16::ProvingKey<E>, ark_groth16::VerifyingKey<E>), String> {
     let key = cache_key(cs);
     let cache_subdir = cache_dir.join(&key);
 
-    if let Some(keys) = load_cached_keys(&cache_subdir) {
+    if let Some(keys) = load_cached_keys::<E>(&cache_subdir) {
         Ok(keys)
     } else {
         let setup_circuit = AchronymeCircuit {
             cs: cs.clone(),
             witness: None,
         };
-        let (pk, vk) = Groth16::<Bn254>::circuit_specific_setup(setup_circuit, &mut OsRng)
+        let (pk, vk) = Groth16::<E>::circuit_specific_setup(setup_circuit, &mut OsRng)
             .map_err(|e| format!("Groth16 setup failed: {e}"))?;
         save_cached_keys(&cache_subdir, &pk, &vk)?;
         Ok((pk, vk))
@@ -133,345 +132,78 @@ pub fn setup_keys(
 }
 
 /// Run trusted setup and return only the verifying key.
-///
-/// Tries the cache first (loading only the VK file). On cache miss, runs
-/// full setup but only serializes the VK to disk — avoids the cost of
-/// writing the much larger proving key when only the VK is needed.
-pub fn setup_vk_only(
+pub fn setup_vk_only<E: Pairing>(
     cs: &ConstraintSystem,
     cache_dir: &Path,
-) -> Result<ark_groth16::VerifyingKey<Bn254>, String> {
+) -> Result<ark_groth16::VerifyingKey<E>, String> {
     let key = cache_key(cs);
     let cache_subdir = cache_dir.join(&key);
 
-    // Try loading just the VK from cache
-    if let Some(vk) = load_cached_vk(&cache_subdir) {
+    if let Some(vk) = load_cached_vk::<E>(&cache_subdir) {
         return Ok(vk);
     }
 
-    // Full setup required — save only VK
     let setup_circuit = AchronymeCircuit {
         cs: cs.clone(),
         witness: None,
     };
-    let (_pk, vk) = Groth16::<Bn254>::circuit_specific_setup(setup_circuit, &mut OsRng)
+    let (_pk, vk) = Groth16::<E>::circuit_specific_setup(setup_circuit, &mut OsRng)
         .map_err(|e| format!("Groth16 setup failed: {e}"))?;
     save_cached_vk(&cache_subdir, &vk)?;
     Ok(vk)
 }
 
-/// Generate a native Groth16 proof using ark-groth16.
+/// Generate a Groth16 proof and return raw ark types.
 ///
-/// Uses cached proving/verifying keys when available.
-pub fn generate_proof(
+/// Curve-specific modules (e.g., `groth16_bn254`) wrap this to add
+/// JSON serialization and return `ProveResult`.
+pub fn generate_proof_raw<E: Pairing>(
     cs: &ConstraintSystem,
     witness: &[FieldElement],
     cache_dir: &Path,
-) -> Result<ProveResult, String> {
-    let (pk, vk) = setup_keys(cs, cache_dir)?;
+) -> Result<
+    (
+        ark_groth16::Proof<E>,
+        ark_groth16::VerifyingKey<E>,
+        Vec<E::ScalarField>,
+    ),
+    String,
+> {
+    let (pk, vk) = setup_keys::<E>(cs, cache_dir)?;
 
-    // Prove
     let prove_circuit = AchronymeCircuit {
         cs: cs.clone(),
         witness: Some(witness.to_vec()),
     };
-    let proof = Groth16::<Bn254>::prove(&pk, prove_circuit, &mut OsRng)
+    let proof = Groth16::<E>::prove(&pk, prove_circuit, &mut OsRng)
         .map_err(|e| format!("Groth16 prove failed: {e}"))?;
 
-    // 4. Extract public inputs (indices 1..=num_pub)
+    // Extract public inputs (indices 1..=num_pub)
     let num_pub = cs.num_pub_inputs();
-    let public_inputs: Vec<Fr> = (1..=num_pub).map(|i| fe_to_ark(&witness[i])).collect();
+    let public_inputs: Vec<E::ScalarField> =
+        (1..=num_pub).map(|i| fe_to_ark(&witness[i])).collect();
 
-    // 5. Verify (sanity check)
-    let valid = Groth16::<Bn254>::verify(&vk, &public_inputs, &proof)
+    // Verify (sanity check)
+    let valid = Groth16::<E>::verify(&vk, &public_inputs, &proof)
         .map_err(|e| format!("Groth16 verify failed: {e}"))?;
     if !valid {
         return Err("Groth16 proof verification failed (internal error)".into());
     }
 
-    // 6. Serialize to snarkjs-compatible JSON
-    let proof_json = serialize_proof_json(&proof);
-    let public_json = serialize_public_json(&public_inputs);
-    let vkey_json = serialize_vkey_json(&vk, num_pub);
-
-    Ok(ProveResult::Proof {
-        proof_json,
-        public_json,
-        vkey_json,
-    })
+    Ok((proof, vk, public_inputs))
 }
 
 // ============================================================================
-// JSON serialization (snarkjs-compatible)
-// ============================================================================
-
-/// Format a G1 affine point as a JSON array of 3 decimal strings [x, y, "1"].
-fn g1_to_json(p: &<Bn254 as Pairing>::G1Affine) -> serde_json::Value {
-    use ark_ec::AffineRepr;
-    if p.is_zero() {
-        return serde_json::json!(["0", "1", "0"]);
-    }
-    let x = p.x().expect("non-zero point has x");
-    let y = p.y().expect("non-zero point has y");
-    serde_json::json!([fr_to_decimal(&x), fr_to_decimal(&y), "1"])
-}
-
-/// Format a G2 affine point as a JSON array of 3 arrays, each with 2 decimal strings.
-fn g2_to_json(p: &<Bn254 as Pairing>::G2Affine) -> serde_json::Value {
-    use ark_ec::AffineRepr;
-    if p.is_zero() {
-        return serde_json::json!([["0", "0"], ["1", "0"], ["0", "0"]]);
-    }
-    let x = p.x().expect("non-zero point has x");
-    let y = p.y().expect("non-zero point has y");
-    // Fq2 has c0, c1 components
-    serde_json::json!([
-        [fr_to_decimal(&x.c0), fr_to_decimal(&x.c1)],
-        [fr_to_decimal(&y.c0), fr_to_decimal(&y.c1)],
-        ["1", "0"]
-    ])
-}
-
-/// Convert an ark field element to a decimal string.
-fn fr_to_decimal<F: PrimeField>(f: &F) -> String {
-    f.into_bigint().to_string()
-}
-
-fn serialize_proof_json(proof: &ark_groth16::Proof<Bn254>) -> String {
-    let obj = serde_json::json!({
-        "pi_a": g1_to_json(&proof.a),
-        "pi_b": g2_to_json(&proof.b),
-        "pi_c": g1_to_json(&proof.c),
-        "protocol": "groth16",
-        "curve": "bn128"
-    });
-    serde_json::to_string_pretty(&obj).unwrap()
-}
-
-fn serialize_public_json(inputs: &[Fr]) -> String {
-    let arr: Vec<String> = inputs.iter().map(fr_to_decimal).collect();
-    serde_json::to_string_pretty(&arr).unwrap()
-}
-
-fn serialize_vkey_json(vk: &ark_groth16::VerifyingKey<Bn254>, num_pub: usize) -> String {
-    let mut ic: Vec<serde_json::Value> = Vec::new();
-    for p in &vk.gamma_abc_g1 {
-        ic.push(g1_to_json(p));
-    }
-    let obj = serde_json::json!({
-        "protocol": "groth16",
-        "curve": "bn128",
-        "nPublic": num_pub,
-        "vk_alpha_1": g1_to_json(&vk.alpha_g1),
-        "vk_beta_2": g2_to_json(&vk.beta_g2),
-        "vk_gamma_2": g2_to_json(&vk.gamma_g2),
-        "vk_delta_2": g2_to_json(&vk.delta_g2),
-        "IC": ic
-    });
-    serde_json::to_string_pretty(&obj).unwrap()
-}
-
-// ============================================================================
-// Solidity calldata formatting
-// ============================================================================
-
-/// Format a Groth16 proof and public inputs as Solidity calldata strings.
-///
-/// Applies EIP-197 coordinate swaps for G2 points (π_B):
-/// arkworks Fq2(c0=real, c1=imag) → EVM (c1=imag, c0=real).
-///
-/// Returns (pA, pB, pC, pubSignals) as decimal strings ready for Solidity.
-pub fn format_solidity_calldata(
-    proof: &ark_groth16::Proof<Bn254>,
-    public_inputs: &[Fr],
-) -> SolidityCalldata {
-    use ark_ec::AffineRepr;
-
-    let a = proof.a;
-    let b = proof.b;
-    let c = proof.c;
-
-    // π_A (G1): direct, no swap
-    let p_a = [
-        fr_to_decimal(&a.x().expect("a.x")),
-        fr_to_decimal(&a.y().expect("a.y")),
-    ];
-
-    // π_B (G2): SWAP c0 ↔ c1 for EIP-197
-    let bx = b.x().expect("b.x");
-    let by = b.y().expect("b.y");
-    let p_b = [
-        [fr_to_decimal(&bx.c1), fr_to_decimal(&bx.c0)], // X: imag first, real second
-        [fr_to_decimal(&by.c1), fr_to_decimal(&by.c0)], // Y: imag first, real second
-    ];
-
-    // π_C (G1): direct, no swap
-    let p_c = [
-        fr_to_decimal(&c.x().expect("c.x")),
-        fr_to_decimal(&c.y().expect("c.y")),
-    ];
-
-    let pub_signals: Vec<String> = public_inputs.iter().map(fr_to_decimal).collect();
-
-    SolidityCalldata {
-        p_a,
-        p_b,
-        p_c,
-        pub_signals,
-    }
-}
-
-/// Structured Solidity calldata for a Groth16 proof.
-pub struct SolidityCalldata {
-    /// π_A point (G1): [x, y]
-    pub p_a: [String; 2],
-    /// π_B point (G2): [[x.c1, x.c0], [y.c1, y.c0]] (EIP-197 order)
-    pub p_b: [[String; 2]; 2],
-    /// π_C point (G1): [x, y]
-    pub p_c: [String; 2],
-    /// Public signals as decimal strings
-    pub pub_signals: Vec<String>,
-}
-
-// ============================================================================
-// JSON deserialization (for verify_proof)
-// ============================================================================
-
-/// Parse a decimal string into an ark Fr.
-fn decimal_to_fr(s: &str) -> Result<Fr, String> {
-    use std::str::FromStr;
-    Fr::from_str(s).map_err(|_| format!("invalid field element: {s}"))
-}
-
-/// Parse a decimal string into an ark Fq (base field).
-fn decimal_to_fq(s: &str) -> Result<ark_bn254::Fq, String> {
-    use std::str::FromStr;
-    ark_bn254::Fq::from_str(s).map_err(|_| format!("invalid base field element: {s}"))
-}
-
-/// Parse a G1 JSON array [x, y, "1"] into an ark G1Affine.
-fn json_to_g1(val: &serde_json::Value) -> Result<<Bn254 as Pairing>::G1Affine, String> {
-    let arr = val.as_array().ok_or("expected array for G1 point")?;
-    if arr.len() != 3 {
-        return Err("G1 point must have 3 elements".into());
-    }
-    let x_str = arr[0].as_str().ok_or("G1 x must be string")?;
-    let y_str = arr[1].as_str().ok_or("G1 y must be string")?;
-    let z_str = arr[2].as_str().ok_or("G1 z must be string")?;
-
-    if z_str == "0" {
-        // Point at infinity
-        use ark_ec::AffineRepr;
-        return Ok(<Bn254 as Pairing>::G1Affine::zero());
-    }
-
-    let x = decimal_to_fq(x_str)?;
-    let y = decimal_to_fq(y_str)?;
-    let p = ark_bn254::G1Affine::new_unchecked(x, y);
-    Ok(p)
-}
-
-/// Parse a G2 JSON array [[x.c0, x.c1], [y.c0, y.c1], ["1","0"]] into an ark G2Affine.
-fn json_to_g2(val: &serde_json::Value) -> Result<<Bn254 as Pairing>::G2Affine, String> {
-    let arr = val.as_array().ok_or("expected array for G2 point")?;
-    if arr.len() != 3 {
-        return Err("G2 point must have 3 elements".into());
-    }
-
-    let x_arr = arr[0].as_array().ok_or("G2 x must be array")?;
-    let y_arr = arr[1].as_array().ok_or("G2 y must be array")?;
-    let z_arr = arr[2].as_array().ok_or("G2 z must be array")?;
-
-    // Check for point at infinity
-    if z_arr.len() >= 2 {
-        let z0 = z_arr[0].as_str().unwrap_or("1");
-        let z1 = z_arr[1].as_str().unwrap_or("0");
-        if z0 == "0" && z1 == "0" {
-            use ark_ec::AffineRepr;
-            return Ok(<Bn254 as Pairing>::G2Affine::zero());
-        }
-    }
-
-    let x_c0 = decimal_to_fq(x_arr[0].as_str().ok_or("x.c0 must be string")?)?;
-    let x_c1 = decimal_to_fq(x_arr[1].as_str().ok_or("x.c1 must be string")?)?;
-    let y_c0 = decimal_to_fq(y_arr[0].as_str().ok_or("y.c0 must be string")?)?;
-    let y_c1 = decimal_to_fq(y_arr[1].as_str().ok_or("y.c1 must be string")?)?;
-
-    let x = ark_bn254::Fq2::new(x_c0, x_c1);
-    let y = ark_bn254::Fq2::new(y_c0, y_c1);
-    let p = ark_bn254::G2Affine::new_unchecked(x, y);
-    Ok(p)
-}
-
-/// Deserialize a snarkjs-format proof JSON string into an ark Proof.
-pub fn deserialize_proof_json(json_str: &str) -> Result<ark_groth16::Proof<Bn254>, String> {
-    let obj: serde_json::Value =
-        serde_json::from_str(json_str).map_err(|e| format!("invalid proof JSON: {e}"))?;
-    let a = json_to_g1(&obj["pi_a"])?;
-    let b = json_to_g2(&obj["pi_b"])?;
-    let c = json_to_g1(&obj["pi_c"])?;
-    Ok(ark_groth16::Proof { a, b, c })
-}
-
-/// Deserialize a snarkjs-format public inputs JSON string into ark Fr values.
-pub fn deserialize_public_json(json_str: &str) -> Result<Vec<Fr>, String> {
-    let arr: Vec<String> =
-        serde_json::from_str(json_str).map_err(|e| format!("invalid public JSON: {e}"))?;
-    arr.iter().map(|s| decimal_to_fr(s)).collect()
-}
-
-/// Deserialize a snarkjs-format verifying key JSON string into an ark VerifyingKey.
-pub fn deserialize_vkey_json(json_str: &str) -> Result<ark_groth16::VerifyingKey<Bn254>, String> {
-    let obj: serde_json::Value =
-        serde_json::from_str(json_str).map_err(|e| format!("invalid vkey JSON: {e}"))?;
-
-    let alpha_g1 = json_to_g1(&obj["vk_alpha_1"])?;
-    let beta_g2 = json_to_g2(&obj["vk_beta_2"])?;
-    let gamma_g2 = json_to_g2(&obj["vk_gamma_2"])?;
-    let delta_g2 = json_to_g2(&obj["vk_delta_2"])?;
-
-    let ic_arr = obj["IC"].as_array().ok_or("vkey IC must be an array")?;
-    let mut gamma_abc_g1 = Vec::with_capacity(ic_arr.len());
-    for ic in ic_arr {
-        gamma_abc_g1.push(json_to_g1(ic)?);
-    }
-
-    Ok(ark_groth16::VerifyingKey {
-        alpha_g1,
-        beta_g2,
-        gamma_g2,
-        delta_g2,
-        gamma_abc_g1,
-    })
-}
-
-/// Verify a proof using deserialized JSON components.
-pub fn verify_proof_from_json(
-    proof_json: &str,
-    public_json: &str,
-    vkey_json: &str,
-) -> Result<bool, String> {
-    let proof = deserialize_proof_json(proof_json)?;
-    let public_inputs = deserialize_public_json(public_json)?;
-    let vk = deserialize_vkey_json(vkey_json)?;
-    Groth16::<Bn254>::verify(&vk, &public_inputs, &proof)
-        .map_err(|e| format!("verification error: {e}"))
-}
-
-// ============================================================================
-// Cache helpers
+// Cache helpers (generic)
 // ============================================================================
 
 /// Compute a SHA256 cache key from the constraint system structure.
-fn cache_key(cs: &ConstraintSystem) -> String {
+pub fn cache_key(cs: &ConstraintSystem) -> String {
     let mut hasher = Sha256::new();
-    // Version salt — bump when serialization format or setup algorithm changes
     hasher.update(b"achronyme-groth16-cache-v1");
-    // Hash structural parameters
     hasher.update(cs.num_variables().to_le_bytes());
     hasher.update(cs.num_pub_inputs().to_le_bytes());
     hasher.update(cs.num_constraints().to_le_bytes());
-    // Hash each constraint's terms
     for c in cs.constraints() {
         hash_lc(&mut hasher, &c.a);
         hash_lc(&mut hasher, &c.b);
@@ -482,8 +214,6 @@ fn cache_key(cs: &ConstraintSystem) -> String {
 }
 
 fn hash_lc(hasher: &mut Sha256, lc: &constraints::r1cs::LinearCombination) {
-    // Sort terms by variable index for canonical ordering — avoids
-    // cache misses when semantically identical LCs have different term order.
     let mut terms: Vec<_> = lc.terms.iter().collect();
     terms.sort_by_key(|(var, _)| var.index());
     hasher.update((terms.len() as u64).to_le_bytes());
@@ -493,16 +223,16 @@ fn hash_lc(hasher: &mut Sha256, lc: &constraints::r1cs::LinearCombination) {
     }
 }
 
-fn load_cached_vk(dir: &Path) -> Option<ark_groth16::VerifyingKey<Bn254>> {
+fn load_cached_vk<E: Pairing>(dir: &Path) -> Option<ark_groth16::VerifyingKey<E>> {
     let vk_path = dir.join("verifying_key.bin");
-    if !vk_path.exists() {
-        return None;
-    }
     let vk_bytes = std::fs::read(&vk_path).ok()?;
-    ark_groth16::VerifyingKey::<Bn254>::deserialize_compressed(&vk_bytes[..]).ok()
+    ark_groth16::VerifyingKey::<E>::deserialize_compressed(&vk_bytes[..]).ok()
 }
 
-fn save_cached_vk(dir: &Path, vk: &ark_groth16::VerifyingKey<Bn254>) -> Result<(), String> {
+fn save_cached_vk<E: Pairing>(
+    dir: &Path,
+    vk: &ark_groth16::VerifyingKey<E>,
+) -> Result<(), String> {
     std::fs::create_dir_all(dir).map_err(|e| format!("failed to create cache dir: {e}"))?;
     let mut vk_buf = Vec::new();
     vk.serialize_compressed(&mut vk_buf)
@@ -512,12 +242,9 @@ fn save_cached_vk(dir: &Path, vk: &ark_groth16::VerifyingKey<Bn254>) -> Result<(
     Ok(())
 }
 
-fn load_cached_keys(
+fn load_cached_keys<E: Pairing>(
     dir: &Path,
-) -> Option<(
-    ark_groth16::ProvingKey<Bn254>,
-    ark_groth16::VerifyingKey<Bn254>,
-)> {
+) -> Option<(ark_groth16::ProvingKey<E>, ark_groth16::VerifyingKey<E>)> {
     let pk_path = dir.join("proving_key.bin");
     let vk_path = dir.join("verifying_key.bin");
     if !pk_path.exists() || !vk_path.exists() {
@@ -525,15 +252,15 @@ fn load_cached_keys(
     }
     let pk_bytes = std::fs::read(&pk_path).ok()?;
     let vk_bytes = std::fs::read(&vk_path).ok()?;
-    let pk = ark_groth16::ProvingKey::<Bn254>::deserialize_compressed(&pk_bytes[..]).ok()?;
-    let vk = ark_groth16::VerifyingKey::<Bn254>::deserialize_compressed(&vk_bytes[..]).ok()?;
+    let pk = ark_groth16::ProvingKey::<E>::deserialize_compressed(&pk_bytes[..]).ok()?;
+    let vk = ark_groth16::VerifyingKey::<E>::deserialize_compressed(&vk_bytes[..]).ok()?;
     Some((pk, vk))
 }
 
-fn save_cached_keys(
+fn save_cached_keys<E: Pairing>(
     dir: &Path,
-    pk: &ark_groth16::ProvingKey<Bn254>,
-    vk: &ark_groth16::VerifyingKey<Bn254>,
+    pk: &ark_groth16::ProvingKey<E>,
+    vk: &ark_groth16::VerifyingKey<E>,
 ) -> Result<(), String> {
     std::fs::create_dir_all(dir).map_err(|e| format!("failed to create cache dir: {e}"))?;
 

--- a/proving/src/groth16.rs
+++ b/proving/src/groth16.rs
@@ -157,6 +157,7 @@ pub fn setup_vk_only<E: Pairing>(
 ///
 /// Curve-specific modules (e.g., `groth16_bn254`) wrap this to add
 /// JSON serialization and return `ProveResult`.
+#[allow(clippy::type_complexity)]
 pub fn generate_proof_raw<E: Pairing>(
     cs: &ConstraintSystem,
     witness: &[FieldElement],
@@ -229,10 +230,7 @@ fn load_cached_vk<E: Pairing>(dir: &Path) -> Option<ark_groth16::VerifyingKey<E>
     ark_groth16::VerifyingKey::<E>::deserialize_compressed(&vk_bytes[..]).ok()
 }
 
-fn save_cached_vk<E: Pairing>(
-    dir: &Path,
-    vk: &ark_groth16::VerifyingKey<E>,
-) -> Result<(), String> {
+fn save_cached_vk<E: Pairing>(dir: &Path, vk: &ark_groth16::VerifyingKey<E>) -> Result<(), String> {
     std::fs::create_dir_all(dir).map_err(|e| format!("failed to create cache dir: {e}"))?;
     let mut vk_buf = Vec::new();
     vk.serialize_compressed(&mut vk_buf)

--- a/proving/src/groth16_bn254.rs
+++ b/proving/src/groth16_bn254.rs
@@ -151,8 +151,14 @@ pub fn format_solidity_calldata(
     let bx = b.x().expect("b.x");
     let by = b.y().expect("b.y");
     let p_b = [
-        [groth16::fr_to_decimal(&bx.c1), groth16::fr_to_decimal(&bx.c0)],
-        [groth16::fr_to_decimal(&by.c1), groth16::fr_to_decimal(&by.c0)],
+        [
+            groth16::fr_to_decimal(&bx.c1),
+            groth16::fr_to_decimal(&bx.c0),
+        ],
+        [
+            groth16::fr_to_decimal(&by.c1),
+            groth16::fr_to_decimal(&by.c0),
+        ],
     ];
 
     let p_c = [

--- a/proving/src/groth16_bn254.rs
+++ b/proving/src/groth16_bn254.rs
@@ -1,0 +1,298 @@
+//! BN254-specific Groth16 proof generation and snarkjs-compatible serialization.
+//!
+//! Delegates proof generation to the generic `groth16` module, then applies
+//! BN254-specific JSON serialization (snarkjs format) and Solidity calldata
+//! formatting (EIP-197 coordinate order).
+
+use std::path::Path;
+
+use ark_bn254::{Bn254, Fq, Fq2, Fr, G1Affine, G2Affine};
+use ark_ec::pairing::Pairing;
+
+use constraints::r1cs::ConstraintSystem;
+use memory::FieldElement;
+use vm::ProveResult;
+
+use crate::groth16;
+
+// ============================================================================
+// Public API (BN254-specialized wrappers)
+// ============================================================================
+
+/// Run trusted setup (or load cached keys) for BN254 Groth16.
+pub fn setup_keys(
+    cs: &ConstraintSystem,
+    cache_dir: &Path,
+) -> Result<
+    (
+        ark_groth16::ProvingKey<Bn254>,
+        ark_groth16::VerifyingKey<Bn254>,
+    ),
+    String,
+> {
+    groth16::setup_keys::<Bn254>(cs, cache_dir)
+}
+
+/// Run trusted setup and return only the verifying key (BN254).
+pub fn setup_vk_only(
+    cs: &ConstraintSystem,
+    cache_dir: &Path,
+) -> Result<ark_groth16::VerifyingKey<Bn254>, String> {
+    groth16::setup_vk_only::<Bn254>(cs, cache_dir)
+}
+
+/// Generate a BN254 Groth16 proof with snarkjs-compatible JSON output.
+pub fn generate_proof(
+    cs: &ConstraintSystem,
+    witness: &[FieldElement],
+    cache_dir: &Path,
+) -> Result<ProveResult, String> {
+    let (proof, vk, public_inputs) = groth16::generate_proof_raw::<Bn254>(cs, witness, cache_dir)?;
+
+    let proof_json = serialize_proof_json(&proof);
+    let public_json = serialize_public_json(&public_inputs);
+    let vkey_json = serialize_vkey_json(&vk, cs.num_pub_inputs());
+
+    Ok(ProveResult::Proof {
+        proof_json,
+        public_json,
+        vkey_json,
+    })
+}
+
+// ============================================================================
+// JSON serialization (snarkjs-compatible, BN254)
+// ============================================================================
+
+/// Format a G1 affine point as a JSON array of 3 decimal strings [x, y, "1"].
+fn g1_to_json(p: &<Bn254 as Pairing>::G1Affine) -> serde_json::Value {
+    use ark_ec::AffineRepr;
+    if p.is_zero() {
+        return serde_json::json!(["0", "1", "0"]);
+    }
+    let x = p.x().expect("non-zero point has x");
+    let y = p.y().expect("non-zero point has y");
+    serde_json::json!([groth16::fr_to_decimal(&x), groth16::fr_to_decimal(&y), "1"])
+}
+
+/// Format a G2 affine point as a JSON array of 3 arrays, each with 2 decimal strings.
+fn g2_to_json(p: &<Bn254 as Pairing>::G2Affine) -> serde_json::Value {
+    use ark_ec::AffineRepr;
+    if p.is_zero() {
+        return serde_json::json!([["0", "0"], ["1", "0"], ["0", "0"]]);
+    }
+    let x = p.x().expect("non-zero point has x");
+    let y = p.y().expect("non-zero point has y");
+    serde_json::json!([
+        [groth16::fr_to_decimal(&x.c0), groth16::fr_to_decimal(&x.c1)],
+        [groth16::fr_to_decimal(&y.c0), groth16::fr_to_decimal(&y.c1)],
+        ["1", "0"]
+    ])
+}
+
+fn serialize_proof_json(proof: &ark_groth16::Proof<Bn254>) -> String {
+    let obj = serde_json::json!({
+        "pi_a": g1_to_json(&proof.a),
+        "pi_b": g2_to_json(&proof.b),
+        "pi_c": g1_to_json(&proof.c),
+        "protocol": "groth16",
+        "curve": "bn128"
+    });
+    serde_json::to_string_pretty(&obj).unwrap()
+}
+
+fn serialize_public_json(inputs: &[Fr]) -> String {
+    let arr: Vec<String> = inputs.iter().map(groth16::fr_to_decimal).collect();
+    serde_json::to_string_pretty(&arr).unwrap()
+}
+
+fn serialize_vkey_json(vk: &ark_groth16::VerifyingKey<Bn254>, num_pub: usize) -> String {
+    let mut ic: Vec<serde_json::Value> = Vec::new();
+    for p in &vk.gamma_abc_g1 {
+        ic.push(g1_to_json(p));
+    }
+    let obj = serde_json::json!({
+        "protocol": "groth16",
+        "curve": "bn128",
+        "nPublic": num_pub,
+        "vk_alpha_1": g1_to_json(&vk.alpha_g1),
+        "vk_beta_2": g2_to_json(&vk.beta_g2),
+        "vk_gamma_2": g2_to_json(&vk.gamma_g2),
+        "vk_delta_2": g2_to_json(&vk.delta_g2),
+        "IC": ic
+    });
+    serde_json::to_string_pretty(&obj).unwrap()
+}
+
+// ============================================================================
+// Solidity calldata formatting (BN254, EIP-197)
+// ============================================================================
+
+/// Format a Groth16 proof and public inputs as Solidity calldata strings.
+///
+/// Applies EIP-197 coordinate swaps for G2 points (π_B):
+/// arkworks Fq2(c0=real, c1=imag) → EVM (c1=imag, c0=real).
+pub fn format_solidity_calldata(
+    proof: &ark_groth16::Proof<Bn254>,
+    public_inputs: &[Fr],
+) -> SolidityCalldata {
+    use ark_ec::AffineRepr;
+
+    let a = proof.a;
+    let b = proof.b;
+    let c = proof.c;
+
+    let p_a = [
+        groth16::fr_to_decimal(&a.x().expect("a.x")),
+        groth16::fr_to_decimal(&a.y().expect("a.y")),
+    ];
+
+    // π_B (G2): SWAP c0 ↔ c1 for EIP-197
+    let bx = b.x().expect("b.x");
+    let by = b.y().expect("b.y");
+    let p_b = [
+        [groth16::fr_to_decimal(&bx.c1), groth16::fr_to_decimal(&bx.c0)],
+        [groth16::fr_to_decimal(&by.c1), groth16::fr_to_decimal(&by.c0)],
+    ];
+
+    let p_c = [
+        groth16::fr_to_decimal(&c.x().expect("c.x")),
+        groth16::fr_to_decimal(&c.y().expect("c.y")),
+    ];
+
+    let pub_signals: Vec<String> = public_inputs.iter().map(groth16::fr_to_decimal).collect();
+
+    SolidityCalldata {
+        p_a,
+        p_b,
+        p_c,
+        pub_signals,
+    }
+}
+
+/// Structured Solidity calldata for a Groth16 proof.
+pub struct SolidityCalldata {
+    pub p_a: [String; 2],
+    pub p_b: [[String; 2]; 2],
+    pub p_c: [String; 2],
+    pub pub_signals: Vec<String>,
+}
+
+// ============================================================================
+// JSON deserialization (for verify_proof, BN254)
+// ============================================================================
+
+fn decimal_to_fr(s: &str) -> Result<Fr, String> {
+    use std::str::FromStr;
+    Fr::from_str(s).map_err(|_| format!("invalid field element: {s}"))
+}
+
+fn decimal_to_fq(s: &str) -> Result<Fq, String> {
+    use std::str::FromStr;
+    Fq::from_str(s).map_err(|_| format!("invalid base field element: {s}"))
+}
+
+fn json_to_g1(val: &serde_json::Value) -> Result<G1Affine, String> {
+    let arr = val.as_array().ok_or("expected array for G1 point")?;
+    if arr.len() != 3 {
+        return Err("G1 point must have 3 elements".into());
+    }
+    let x_str = arr[0].as_str().ok_or("G1 x must be string")?;
+    let y_str = arr[1].as_str().ok_or("G1 y must be string")?;
+    let z_str = arr[2].as_str().ok_or("G1 z must be string")?;
+
+    if z_str == "0" {
+        use ark_ec::AffineRepr;
+        return Ok(G1Affine::zero());
+    }
+
+    let x = decimal_to_fq(x_str)?;
+    let y = decimal_to_fq(y_str)?;
+    Ok(G1Affine::new_unchecked(x, y))
+}
+
+fn json_to_g2(val: &serde_json::Value) -> Result<G2Affine, String> {
+    let arr = val.as_array().ok_or("expected array for G2 point")?;
+    if arr.len() != 3 {
+        return Err("G2 point must have 3 elements".into());
+    }
+
+    let x_arr = arr[0].as_array().ok_or("G2 x must be array")?;
+    let y_arr = arr[1].as_array().ok_or("G2 y must be array")?;
+    let z_arr = arr[2].as_array().ok_or("G2 z must be array")?;
+
+    if z_arr.len() >= 2 {
+        let z0 = z_arr[0].as_str().unwrap_or("1");
+        let z1 = z_arr[1].as_str().unwrap_or("0");
+        if z0 == "0" && z1 == "0" {
+            use ark_ec::AffineRepr;
+            return Ok(G2Affine::zero());
+        }
+    }
+
+    let x_c0 = decimal_to_fq(x_arr[0].as_str().ok_or("x.c0 must be string")?)?;
+    let x_c1 = decimal_to_fq(x_arr[1].as_str().ok_or("x.c1 must be string")?)?;
+    let y_c0 = decimal_to_fq(y_arr[0].as_str().ok_or("y.c0 must be string")?)?;
+    let y_c1 = decimal_to_fq(y_arr[1].as_str().ok_or("y.c1 must be string")?)?;
+
+    let x = Fq2::new(x_c0, x_c1);
+    let y = Fq2::new(y_c0, y_c1);
+    Ok(G2Affine::new_unchecked(x, y))
+}
+
+/// Deserialize a snarkjs-format proof JSON string into an ark Proof.
+pub fn deserialize_proof_json(json_str: &str) -> Result<ark_groth16::Proof<Bn254>, String> {
+    let obj: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid proof JSON: {e}"))?;
+    let a = json_to_g1(&obj["pi_a"])?;
+    let b = json_to_g2(&obj["pi_b"])?;
+    let c = json_to_g1(&obj["pi_c"])?;
+    Ok(ark_groth16::Proof { a, b, c })
+}
+
+/// Deserialize a snarkjs-format public inputs JSON string into ark Fr values.
+pub fn deserialize_public_json(json_str: &str) -> Result<Vec<Fr>, String> {
+    let arr: Vec<String> =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid public JSON: {e}"))?;
+    arr.iter().map(|s| decimal_to_fr(s)).collect()
+}
+
+/// Deserialize a snarkjs-format verifying key JSON string into an ark VerifyingKey.
+pub fn deserialize_vkey_json(json_str: &str) -> Result<ark_groth16::VerifyingKey<Bn254>, String> {
+    let obj: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid vkey JSON: {e}"))?;
+
+    let alpha_g1 = json_to_g1(&obj["vk_alpha_1"])?;
+    let beta_g2 = json_to_g2(&obj["vk_beta_2"])?;
+    let gamma_g2 = json_to_g2(&obj["vk_gamma_2"])?;
+    let delta_g2 = json_to_g2(&obj["vk_delta_2"])?;
+
+    let ic_arr = obj["IC"].as_array().ok_or("vkey IC must be an array")?;
+    let mut gamma_abc_g1 = Vec::with_capacity(ic_arr.len());
+    for ic in ic_arr {
+        gamma_abc_g1.push(json_to_g1(ic)?);
+    }
+
+    Ok(ark_groth16::VerifyingKey {
+        alpha_g1,
+        beta_g2,
+        gamma_g2,
+        delta_g2,
+        gamma_abc_g1,
+    })
+}
+
+/// Verify a proof using deserialized JSON components (BN254).
+pub fn verify_proof_from_json(
+    proof_json: &str,
+    public_json: &str,
+    vkey_json: &str,
+) -> Result<bool, String> {
+    use ark_groth16::Groth16;
+    use ark_snark::SNARK;
+    let proof = deserialize_proof_json(proof_json)?;
+    let public_inputs = deserialize_public_json(public_json)?;
+    let vk = deserialize_vkey_json(vkey_json)?;
+    Groth16::<Bn254>::verify(&vk, &public_inputs, &proof)
+        .map_err(|e| format!("verification error: {e}"))
+}

--- a/proving/src/lib.rs
+++ b/proving/src/lib.rs
@@ -1,3 +1,11 @@
+#[cfg(feature = "groth16-core")]
 pub mod groth16;
+
+#[cfg(feature = "groth16-bn254")]
+pub mod groth16_bn254;
+
+#[cfg(feature = "plonk-bn254")]
 pub mod halo2_proof;
+
+#[cfg(feature = "groth16-bn254")]
 pub mod solidity;


### PR DESCRIPTION
## Summary

- Split `groth16.rs` into generic core (`Pairing`-generic) and `groth16_bn254.rs` (BN254-specific snarkjs serialization)
- Add Cargo feature flags: `groth16-bn254` (default), `groth16-bls12-381`, `plonk-bn254` (default), `groth16-core`
- All proving modules feature-gated in `lib.rs`
- `ark-bls12-381` added as optional dependency
- Solidity verifier gated to `groth16-bn254` (EVM precompiles)
- `--no-default-features` compiles clean (empty crate)

## Test plan

- [x] 2663 tests pass (`cargo test --workspace`)
- [x] `cargo check -p proving --no-default-features` clean
- [x] `cargo check -p proving --features groth16-bn254` clean
- [x] `cargo check -p proving --features plonk-bn254` clean
- [x] `cargo check -p proving --features groth16-bls12-381` clean
- [x] `cargo fmt` + `cargo clippy` clean