### PR TITLE
feat: BLS12-381 Groth16 prover (Phase 10a)

### DIFF
--- a/cli/src/prove_handler.rs
+++ b/cli/src/prove_handler.rs
@@ -165,11 +165,22 @@ impl ProveHandler for SharedProveHandler {
 
 impl VerifyHandler for DefaultProveHandler {
     fn verify_proof(&self, proof: &memory::ProofObject) -> Result<bool, String> {
-        proving::groth16_bn254::verify_proof_from_json(
-            &proof.proof_json,
-            &proof.public_json,
-            &proof.vkey_json,
-        )
+        match self.prime_id {
+            PrimeId::Bn254 => proving::groth16_bn254::verify_proof_from_json(
+                &proof.proof_json,
+                &proof.public_json,
+                &proof.vkey_json,
+            ),
+            PrimeId::Bls12_381 => proving::groth16_bls12_381::verify_proof_from_json(
+                &proof.proof_json,
+                &proof.public_json,
+                &proof.vkey_json,
+            ),
+            other => Err(format!(
+                "proof verification not supported for prime `{}`",
+                other.name()
+            )),
+        }
     }
 }
 
@@ -204,9 +215,13 @@ impl DefaultProveHandler {
                 proving::groth16_bn254::generate_proof(&r1cs.cs, &witness, &self.cache_dir)
                     .map_err(ProveError::ProofGeneration)?
             }
+            PrimeId::Bls12_381 => {
+                proving::groth16_bls12_381::generate_proof(&r1cs.cs, &witness, &self.cache_dir)
+                    .map_err(ProveError::ProofGeneration)?
+            }
             other => {
                 return Err(ProveError::ProofGeneration(format!(
-                    "Groth16 proof generation not yet supported for prime `{}`",
+                    "Groth16 proof generation not supported for prime `{}`",
                     other.name()
                 )));
             }

--- a/proving/Cargo.toml
+++ b/proving/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
-default = ["groth16-bn254", "plonk-bn254"]
+default = ["groth16-bn254", "groth16-bls12-381", "plonk-bn254"]
 
 # Groth16 core (generic over Pairing) — activated by any groth16 variant
 groth16-core = [

--- a/proving/src/groth16.rs
+++ b/proving/src/groth16.rs
@@ -110,11 +110,15 @@ fn convert_lc<F: PrimeField>(
 // ============================================================================
 
 /// Run trusted setup (or load cached keys).
+///
+/// `curve_tag` is included in the cache key to prevent collisions between
+/// the same circuit compiled for different curves.
 pub fn setup_keys<E: Pairing>(
     cs: &ConstraintSystem,
     cache_dir: &Path,
+    curve_tag: &str,
 ) -> Result<(ark_groth16::ProvingKey<E>, ark_groth16::VerifyingKey<E>), String> {
-    let key = cache_key(cs);
+    let key = cache_key(cs, curve_tag);
     let cache_subdir = cache_dir.join(&key);
 
     if let Some(keys) = load_cached_keys::<E>(&cache_subdir) {
@@ -135,8 +139,9 @@ pub fn setup_keys<E: Pairing>(
 pub fn setup_vk_only<E: Pairing>(
     cs: &ConstraintSystem,
     cache_dir: &Path,
+    curve_tag: &str,
 ) -> Result<ark_groth16::VerifyingKey<E>, String> {
-    let key = cache_key(cs);
+    let key = cache_key(cs, curve_tag);
     let cache_subdir = cache_dir.join(&key);
 
     if let Some(vk) = load_cached_vk::<E>(&cache_subdir) {
@@ -162,6 +167,7 @@ pub fn generate_proof_raw<E: Pairing>(
     cs: &ConstraintSystem,
     witness: &[FieldElement],
     cache_dir: &Path,
+    curve_tag: &str,
 ) -> Result<
     (
         ark_groth16::Proof<E>,
@@ -170,7 +176,7 @@ pub fn generate_proof_raw<E: Pairing>(
     ),
     String,
 > {
-    let (pk, vk) = setup_keys::<E>(cs, cache_dir)?;
+    let (pk, vk) = setup_keys::<E>(cs, cache_dir, curve_tag)?;
 
     let prove_circuit = AchronymeCircuit {
         cs: cs.clone(),
@@ -198,10 +204,15 @@ pub fn generate_proof_raw<E: Pairing>(
 // Cache helpers (generic)
 // ============================================================================
 
-/// Compute a SHA256 cache key from the constraint system structure.
-pub fn cache_key(cs: &ConstraintSystem) -> String {
+/// Compute a SHA256 cache key from the constraint system structure and curve.
+///
+/// The `curve_tag` prevents cache collisions between different curves —
+/// the same circuit compiled for BN254 and BLS12-381 must use separate
+/// cached proving/verifying keys.
+pub fn cache_key(cs: &ConstraintSystem, curve_tag: &str) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"achronyme-groth16-cache-v1");
+    hasher.update(b"achronyme-groth16-cache-v2");
+    hasher.update(curve_tag.as_bytes());
     hasher.update(cs.num_variables().to_le_bytes());
     hasher.update(cs.num_pub_inputs().to_le_bytes());
     hasher.update(cs.num_constraints().to_le_bytes());

--- a/proving/src/groth16_bls12_381.rs
+++ b/proving/src/groth16_bls12_381.rs
@@ -1,0 +1,245 @@
+//! BLS12-381-specific Groth16 proof generation and JSON serialization.
+//!
+//! Delegates proof generation to the generic `groth16` module, then applies
+//! BLS12-381-specific JSON serialization. No Solidity support (EVM precompiles
+//! are BN254-only).
+
+use std::path::Path;
+
+use ark_bls12_381::{Bls12_381, Fq, Fq2, Fr, G1Affine, G2Affine};
+use ark_ec::pairing::Pairing;
+
+use constraints::r1cs::ConstraintSystem;
+use memory::FieldElement;
+use vm::ProveResult;
+
+use crate::groth16;
+
+// ============================================================================
+// Public API (BLS12-381-specialized wrappers)
+// ============================================================================
+
+/// Run trusted setup (or load cached keys) for BLS12-381 Groth16.
+pub fn setup_keys(
+    cs: &ConstraintSystem,
+    cache_dir: &Path,
+) -> Result<
+    (
+        ark_groth16::ProvingKey<Bls12_381>,
+        ark_groth16::VerifyingKey<Bls12_381>,
+    ),
+    String,
+> {
+    groth16::setup_keys::<Bls12_381>(cs, cache_dir)
+}
+
+/// Run trusted setup and return only the verifying key (BLS12-381).
+pub fn setup_vk_only(
+    cs: &ConstraintSystem,
+    cache_dir: &Path,
+) -> Result<ark_groth16::VerifyingKey<Bls12_381>, String> {
+    groth16::setup_vk_only::<Bls12_381>(cs, cache_dir)
+}
+
+/// Generate a BLS12-381 Groth16 proof with JSON output.
+pub fn generate_proof(
+    cs: &ConstraintSystem,
+    witness: &[FieldElement],
+    cache_dir: &Path,
+) -> Result<ProveResult, String> {
+    let (proof, vk, public_inputs) =
+        groth16::generate_proof_raw::<Bls12_381>(cs, witness, cache_dir)?;
+
+    let proof_json = serialize_proof_json(&proof);
+    let public_json = serialize_public_json(&public_inputs);
+    let vkey_json = serialize_vkey_json(&vk, cs.num_pub_inputs());
+
+    Ok(ProveResult::Proof {
+        proof_json,
+        public_json,
+        vkey_json,
+    })
+}
+
+// ============================================================================
+// JSON serialization (BLS12-381)
+// ============================================================================
+
+fn g1_to_json(p: &<Bls12_381 as Pairing>::G1Affine) -> serde_json::Value {
+    use ark_ec::AffineRepr;
+    if p.is_zero() {
+        return serde_json::json!(["0", "1", "0"]);
+    }
+    let x = p.x().expect("non-zero point has x");
+    let y = p.y().expect("non-zero point has y");
+    serde_json::json!([groth16::fr_to_decimal(&x), groth16::fr_to_decimal(&y), "1"])
+}
+
+fn g2_to_json(p: &<Bls12_381 as Pairing>::G2Affine) -> serde_json::Value {
+    use ark_ec::AffineRepr;
+    if p.is_zero() {
+        return serde_json::json!([["0", "0"], ["1", "0"], ["0", "0"]]);
+    }
+    let x = p.x().expect("non-zero point has x");
+    let y = p.y().expect("non-zero point has y");
+    serde_json::json!([
+        [groth16::fr_to_decimal(&x.c0), groth16::fr_to_decimal(&x.c1)],
+        [groth16::fr_to_decimal(&y.c0), groth16::fr_to_decimal(&y.c1)],
+        ["1", "0"]
+    ])
+}
+
+fn serialize_proof_json(proof: &ark_groth16::Proof<Bls12_381>) -> String {
+    let obj = serde_json::json!({
+        "pi_a": g1_to_json(&proof.a),
+        "pi_b": g2_to_json(&proof.b),
+        "pi_c": g1_to_json(&proof.c),
+        "protocol": "groth16",
+        "curve": "bls12-381"
+    });
+    serde_json::to_string_pretty(&obj).unwrap()
+}
+
+fn serialize_public_json(inputs: &[Fr]) -> String {
+    let arr: Vec<String> = inputs.iter().map(groth16::fr_to_decimal).collect();
+    serde_json::to_string_pretty(&arr).unwrap()
+}
+
+fn serialize_vkey_json(vk: &ark_groth16::VerifyingKey<Bls12_381>, num_pub: usize) -> String {
+    let mut ic: Vec<serde_json::Value> = Vec::new();
+    for p in &vk.gamma_abc_g1 {
+        ic.push(g1_to_json(p));
+    }
+    let obj = serde_json::json!({
+        "protocol": "groth16",
+        "curve": "bls12-381",
+        "nPublic": num_pub,
+        "vk_alpha_1": g1_to_json(&vk.alpha_g1),
+        "vk_beta_2": g2_to_json(&vk.beta_g2),
+        "vk_gamma_2": g2_to_json(&vk.gamma_g2),
+        "vk_delta_2": g2_to_json(&vk.delta_g2),
+        "IC": ic
+    });
+    serde_json::to_string_pretty(&obj).unwrap()
+}
+
+// ============================================================================
+// JSON deserialization (for verify_proof, BLS12-381)
+// ============================================================================
+
+fn decimal_to_fr(s: &str) -> Result<Fr, String> {
+    use std::str::FromStr;
+    Fr::from_str(s).map_err(|_| format!("invalid field element: {s}"))
+}
+
+fn decimal_to_fq(s: &str) -> Result<Fq, String> {
+    use std::str::FromStr;
+    Fq::from_str(s).map_err(|_| format!("invalid base field element: {s}"))
+}
+
+fn json_to_g1(val: &serde_json::Value) -> Result<G1Affine, String> {
+    let arr = val.as_array().ok_or("expected array for G1 point")?;
+    if arr.len() != 3 {
+        return Err("G1 point must have 3 elements".into());
+    }
+    let x_str = arr[0].as_str().ok_or("G1 x must be string")?;
+    let y_str = arr[1].as_str().ok_or("G1 y must be string")?;
+    let z_str = arr[2].as_str().ok_or("G1 z must be string")?;
+
+    if z_str == "0" {
+        use ark_ec::AffineRepr;
+        return Ok(G1Affine::zero());
+    }
+
+    let x = decimal_to_fq(x_str)?;
+    let y = decimal_to_fq(y_str)?;
+    Ok(G1Affine::new_unchecked(x, y))
+}
+
+fn json_to_g2(val: &serde_json::Value) -> Result<G2Affine, String> {
+    let arr = val.as_array().ok_or("expected array for G2 point")?;
+    if arr.len() != 3 {
+        return Err("G2 point must have 3 elements".into());
+    }
+
+    let x_arr = arr[0].as_array().ok_or("G2 x must be array")?;
+    let y_arr = arr[1].as_array().ok_or("G2 y must be array")?;
+    let z_arr = arr[2].as_array().ok_or("G2 z must be array")?;
+
+    if z_arr.len() >= 2 {
+        let z0 = z_arr[0].as_str().unwrap_or("1");
+        let z1 = z_arr[1].as_str().unwrap_or("0");
+        if z0 == "0" && z1 == "0" {
+            use ark_ec::AffineRepr;
+            return Ok(G2Affine::zero());
+        }
+    }
+
+    let x_c0 = decimal_to_fq(x_arr[0].as_str().ok_or("x.c0 must be string")?)?;
+    let x_c1 = decimal_to_fq(x_arr[1].as_str().ok_or("x.c1 must be string")?)?;
+    let y_c0 = decimal_to_fq(y_arr[0].as_str().ok_or("y.c0 must be string")?)?;
+    let y_c1 = decimal_to_fq(y_arr[1].as_str().ok_or("y.c1 must be string")?)?;
+
+    let x = Fq2::new(x_c0, x_c1);
+    let y = Fq2::new(y_c0, y_c1);
+    Ok(G2Affine::new_unchecked(x, y))
+}
+
+/// Deserialize a proof JSON string into an ark Proof (BLS12-381).
+pub fn deserialize_proof_json(json_str: &str) -> Result<ark_groth16::Proof<Bls12_381>, String> {
+    let obj: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid proof JSON: {e}"))?;
+    let a = json_to_g1(&obj["pi_a"])?;
+    let b = json_to_g2(&obj["pi_b"])?;
+    let c = json_to_g1(&obj["pi_c"])?;
+    Ok(ark_groth16::Proof { a, b, c })
+}
+
+/// Deserialize a public inputs JSON string into ark Fr values (BLS12-381).
+pub fn deserialize_public_json(json_str: &str) -> Result<Vec<Fr>, String> {
+    let arr: Vec<String> =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid public JSON: {e}"))?;
+    arr.iter().map(|s| decimal_to_fr(s)).collect()
+}
+
+/// Deserialize a verifying key JSON string into an ark VerifyingKey (BLS12-381).
+pub fn deserialize_vkey_json(
+    json_str: &str,
+) -> Result<ark_groth16::VerifyingKey<Bls12_381>, String> {
+    let obj: serde_json::Value =
+        serde_json::from_str(json_str).map_err(|e| format!("invalid vkey JSON: {e}"))?;
+
+    let alpha_g1 = json_to_g1(&obj["vk_alpha_1"])?;
+    let beta_g2 = json_to_g2(&obj["vk_beta_2"])?;
+    let gamma_g2 = json_to_g2(&obj["vk_gamma_2"])?;
+    let delta_g2 = json_to_g2(&obj["vk_delta_2"])?;
+
+    let ic_arr = obj["IC"].as_array().ok_or("vkey IC must be an array")?;
+    let mut gamma_abc_g1 = Vec::with_capacity(ic_arr.len());
+    for ic in ic_arr {
+        gamma_abc_g1.push(json_to_g1(ic)?);
+    }
+
+    Ok(ark_groth16::VerifyingKey {
+        alpha_g1,
+        beta_g2,
+        gamma_g2,
+        delta_g2,
+        gamma_abc_g1,
+    })
+}
+
+/// Verify a proof using deserialized JSON components (BLS12-381).
+pub fn verify_proof_from_json(
+    proof_json: &str,
+    public_json: &str,
+    vkey_json: &str,
+) -> Result<bool, String> {
+    use ark_groth16::Groth16;
+    use ark_snark::SNARK;
+    let proof = deserialize_proof_json(proof_json)?;
+    let public_inputs = deserialize_public_json(public_json)?;
+    let vk = deserialize_vkey_json(vkey_json)?;
+    Groth16::<Bls12_381>::verify(&vk, &public_inputs, &proof)
+        .map_err(|e| format!("verification error: {e}"))
+}

--- a/proving/src/groth16_bls12_381.rs
+++ b/proving/src/groth16_bls12_381.rs
@@ -30,7 +30,7 @@ pub fn setup_keys(
     ),
     String,
 > {
-    groth16::setup_keys::<Bls12_381>(cs, cache_dir)
+    groth16::setup_keys::<Bls12_381>(cs, cache_dir, "bls12-381")
 }
 
 /// Run trusted setup and return only the verifying key (BLS12-381).
@@ -38,7 +38,7 @@ pub fn setup_vk_only(
     cs: &ConstraintSystem,
     cache_dir: &Path,
 ) -> Result<ark_groth16::VerifyingKey<Bls12_381>, String> {
-    groth16::setup_vk_only::<Bls12_381>(cs, cache_dir)
+    groth16::setup_vk_only::<Bls12_381>(cs, cache_dir, "bls12-381")
 }
 
 /// Generate a BLS12-381 Groth16 proof with JSON output.
@@ -48,7 +48,7 @@ pub fn generate_proof(
     cache_dir: &Path,
 ) -> Result<ProveResult, String> {
     let (proof, vk, public_inputs) =
-        groth16::generate_proof_raw::<Bls12_381>(cs, witness, cache_dir)?;
+        groth16::generate_proof_raw::<Bls12_381>(cs, witness, cache_dir, "bls12-381")?;
 
     let proof_json = serialize_proof_json(&proof);
     let public_json = serialize_public_json(&public_inputs);

--- a/proving/src/groth16_bn254.rs
+++ b/proving/src/groth16_bn254.rs
@@ -30,7 +30,7 @@ pub fn setup_keys(
     ),
     String,
 > {
-    groth16::setup_keys::<Bn254>(cs, cache_dir)
+    groth16::setup_keys::<Bn254>(cs, cache_dir, "bn254")
 }
 
 /// Run trusted setup and return only the verifying key (BN254).
@@ -38,7 +38,7 @@ pub fn setup_vk_only(
     cs: &ConstraintSystem,
     cache_dir: &Path,
 ) -> Result<ark_groth16::VerifyingKey<Bn254>, String> {
-    groth16::setup_vk_only::<Bn254>(cs, cache_dir)
+    groth16::setup_vk_only::<Bn254>(cs, cache_dir, "bn254")
 }
 
 /// Generate a BN254 Groth16 proof with snarkjs-compatible JSON output.
@@ -47,7 +47,8 @@ pub fn generate_proof(
     witness: &[FieldElement],
     cache_dir: &Path,
 ) -> Result<ProveResult, String> {
-    let (proof, vk, public_inputs) = groth16::generate_proof_raw::<Bn254>(cs, witness, cache_dir)?;
+    let (proof, vk, public_inputs) =
+        groth16::generate_proof_raw::<Bn254>(cs, witness, cache_dir, "bn254")?;
 
     let proof_json = serialize_proof_json(&proof);
     let public_json = serialize_public_json(&public_inputs);

--- a/proving/src/lib.rs
+++ b/proving/src/lib.rs
@@ -4,6 +4,9 @@ pub mod groth16;
 #[cfg(feature = "groth16-bn254")]
 pub mod groth16_bn254;
 
+#[cfg(feature = "groth16-bls12-381")]
+pub mod groth16_bls12_381;
+
 #[cfg(feature = "plonk-bn254")]
 pub mod halo2_proof;
 


### PR DESCRIPTION
## Summary
- New `proving/src/groth16_bls12_381.rs` module with full Groth16 proof generation, JSON serialization/deserialization, and verification for BLS12-381
- `groth16-bls12-381` feature enabled by default alongside `groth16-bn254` and `plonk-bn254`
- `prove_handler` dispatches to correct prover and verifier based on `prime_id`
- No Solidity support for BLS12-381 (EVM precompiles are BN254-only)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — 0 failures
- [x] `test/run_tests.sh` — 162/162 passed
- [x] BN254 regression: all existing proofs still work