### PR TITLE
Phase 10B: cross-prime E2E test matrix + BLS12-381 bug fixes

### DIFF
--- a/cli/src/commands/circuit.rs
+++ b/cli/src/commands/circuit.rs
@@ -360,6 +360,7 @@ fn run_r1cs_pipeline(
     proven: &std::collections::HashSet<ir::SsaVar>,
 ) -> Result<()> {
     let mut compiler = R1CSCompiler::new();
+    compiler.prime_id = prime_id;
     compiler.set_proven_boolean(proven.clone());
 
     // Count public/witness inputs from IR

--- a/cli/src/prove_handler.rs
+++ b/cli/src/prove_handler.rs
@@ -197,6 +197,7 @@ impl DefaultProveHandler {
         inputs: &HashMap<String, FieldElement>,
     ) -> Result<ProveResult, ProveError> {
         let mut r1cs = R1CSCompiler::new();
+        r1cs.prime_id = self.prime_id;
         let proven = ir::passes::bool_prop::compute_proven_boolean(program);
         r1cs.set_proven_boolean(proven);
         let witness = r1cs

--- a/compiler/src/r1cs_backend.rs
+++ b/compiler/src/r1cs_backend.rs
@@ -1,5 +1,6 @@
 use constraints::poseidon::PoseidonParams;
 use constraints::r1cs::{ConstraintSystem, LinearCombination, Variable};
+use memory::field::PrimeId;
 use memory::FieldElement;
 use std::collections::HashMap;
 
@@ -37,6 +38,9 @@ pub struct R1CSCompiler {
     pub(crate) poseidon_params: Option<PoseidonParams>,
     /// Witness generation trace: records each intermediate variable allocation.
     pub witness_ops: Vec<WitnessOp>,
+    /// Prime field for this compilation.
+    /// Determines the default bit width for range checks and comparisons.
+    pub prime_id: PrimeId,
     /// SSA variables proven to be boolean by bool_prop analysis.
     /// Boolean enforcement constraints are skipped for these.
     proven_boolean: std::collections::HashSet<ir::types::SsaVar>,
@@ -63,6 +67,7 @@ impl R1CSCompiler {
             bindings: HashMap::new(),
             public_inputs: Vec::new(),
             witnesses: Vec::new(),
+            prime_id: PrimeId::Bn254,
             poseidon_params: None,
             witness_ops: Vec::new(),
             proven_boolean: std::collections::HashSet::new(),
@@ -356,17 +361,18 @@ impl R1CSCompiler {
                     let b = lookup(&lc_map, rhs)?;
                     let bound_a = range_bounds.get(lhs).copied();
                     let bound_b = range_bounds.get(rhs).copied();
+                    let default_bits = self.default_range_bits();
 
                     let effective_bits = match (bound_a, bound_b) {
                         (Some(ba), Some(bb)) => ba.max(bb),
                         _ => {
                             if bound_a.is_none() {
-                                self.enforce_252_range(&a);
+                                self.enforce_default_range(&a);
                             }
                             if bound_b.is_none() {
-                                self.enforce_252_range(&b);
+                                self.enforce_default_range(&b);
                             }
-                            252
+                            default_bits
                         }
                     };
 
@@ -381,17 +387,18 @@ impl R1CSCompiler {
                     let b = lookup(&lc_map, rhs)?;
                     let bound_a = range_bounds.get(lhs).copied();
                     let bound_b = range_bounds.get(rhs).copied();
+                    let default_bits = self.default_range_bits();
 
                     let effective_bits = match (bound_a, bound_b) {
                         (Some(ba), Some(bb)) => ba.max(bb),
                         _ => {
                             if bound_a.is_none() {
-                                self.enforce_252_range(&a);
+                                self.enforce_default_range(&a);
                             }
                             if bound_b.is_none() {
-                                self.enforce_252_range(&b);
+                                self.enforce_default_range(&b);
                             }
-                            252
+                            default_bits
                         }
                     };
 

--- a/compiler/src/r1cs_gadgets.rs
+++ b/compiler/src/r1cs_gadgets.rs
@@ -5,12 +5,13 @@ use crate::r1cs_backend::R1CSCompiler;
 use crate::r1cs_error::R1CSError;
 use crate::witness_gen::WitnessOp;
 
-/// Pre-computed table of 2^0 .. 2^252 as FieldElements.
-/// Initialized once on first access, O(253) total instead of O(n) per call.
-static POWERS_OF_TWO: std::sync::LazyLock<[FieldElement; 253]> = std::sync::LazyLock::new(|| {
-    let mut table = [FieldElement::ZERO; 253];
+/// Pre-computed table of 2^0 .. 2^255 as FieldElements.
+/// Covers all supported prime fields (BN254=254 bits, BLS12-381=255 bits).
+/// Initialized once on first access, O(256) total instead of O(n) per call.
+static POWERS_OF_TWO: std::sync::LazyLock<[FieldElement; 256]> = std::sync::LazyLock::new(|| {
+    let mut table = [FieldElement::ZERO; 256];
     table[0] = FieldElement::ONE;
-    for i in 1..253 {
+    for i in 1..256 {
         table[i] = table[i - 1].add(&table[i - 1]);
     }
     table
@@ -125,9 +126,16 @@ impl R1CSCompiler {
         self.cs.enforce_equal(val.clone(), sum);
     }
 
-    /// Enforce that `val` fits in 252 bits: `val ∈ [0, 2^252)`.
-    pub(crate) fn enforce_252_range(&mut self, val: &LinearCombination) {
-        self.enforce_n_range(val, 252);
+    /// Default range bit width: `modulus_bit_size - 2`.
+    /// BN254 → 252, BLS12-381 → 253.
+    pub(crate) fn default_range_bits(&self) -> u32 {
+        self.prime_id.modulus_bit_size() - 2
+    }
+
+    /// Enforce that `val` fits in the default range for the active prime field.
+    pub(crate) fn enforce_default_range(&mut self, val: &LinearCombination) {
+        let bits = self.default_range_bits();
+        self.enforce_n_range(val, bits);
     }
 
     /// Compile an IsLt check via `num_bits`-bit decomposition.

--- a/proving/src/groth16.rs
+++ b/proving/src/groth16.rs
@@ -26,11 +26,35 @@ use memory::FieldElement;
 
 /// Convert an Achronyme `FieldElement` to an ark scalar field element.
 ///
-/// Uses `from_le_bytes_mod_order` — works for any `PrimeField` regardless
-/// of modulus. The caller must ensure the source `FieldElement` was produced
-/// under the same prime; otherwise the value wraps mod the target prime.
+/// The source `FieldElement` uses BN254 arithmetic internally. When
+/// converting to a different field (e.g. BLS12-381), negative values
+/// like `-1` are stored as `p_bn254 - 1`. A naïve byte reinterpretation
+/// would give the wrong value in the target field.
+///
+/// This function detects "negative" source values (canonical > p/2) and
+/// maps them to the correct negation in the target field:
+///   source < p/2  →  target = source  (positive, same integer)
+///   source >= p/2 →  target = -(p_bn254 - source)  (negative, re-negated)
 pub fn fe_to_ark<F: PrimeField>(fe: &FieldElement) -> F {
-    F::from_le_bytes_mod_order(&fe.to_le_bytes())
+    let bytes = fe.to_le_bytes();
+    let canonical = fe.to_canonical();
+
+    // Check if value is in the upper half of BN254's field (i.e., "negative")
+    // p_bn254 ≈ 0x30644e72... << 192, so half ≈ 0x18322739... << 192.
+    // Quick check: compare the top limb against MODULUS[3] / 2.
+    const BN254_MOD: [u64; 4] = memory::field::MODULUS;
+    let is_negative = canonical[3] > (BN254_MOD[3] / 2)
+        || (canonical[3] == (BN254_MOD[3] / 2) && canonical[2] > (BN254_MOD[2] / 2));
+
+    if is_negative {
+        // Compute abs = p_bn254 - canonical (the positive magnitude)
+        let neg = fe.neg();
+        let neg_bytes = neg.to_le_bytes();
+        let pos_in_target = F::from_le_bytes_mod_order(&neg_bytes);
+        -pos_in_target
+    } else {
+        F::from_le_bytes_mod_order(&bytes)
+    }
 }
 
 /// Convert an ark field element to a decimal string.

--- a/test/cross_prime_tests.sh
+++ b/test/cross_prime_tests.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Cross-prime test matrix for Achronyme
+#
+# Tests the same circuits and prove blocks across multiple prime fields.
+#
+# Matrix:
+#   BN254     + R1CS     -> circuit + prove (Groth16) [already in run_tests.sh]
+#   BN254     + Plonkish -> circuit (PlonK)           [already in run_tests.sh]
+#   BLS12-381 + R1CS     -> circuit + prove (Groth16) [THIS SCRIPT]
+#
+# Exclusions (BLS12-381):
+#   - Poseidon-based: backends hardcode BN254 Poseidon params (not wired to prime_id)
+#   - Division (/): requires field inverse (BN254-specific witness values)
+#   - IsNotEqual (!=, assert(x==y)): requires field inverse (IsZero gadget)
+#   - Unbounded comparisons (<, <=): work if both operands have range bounds,
+#     but the default enforce_default_range path is fine; the issue is only when
+#     combined with IsNotEqual.
+#
+# Root cause: FieldElement<Bn254Fr> performs arithmetic in BN254's field.
+# Field inverses (1/x) produce values specific to BN254 that are invalid in
+# BLS12-381. This will be resolved when the constraint system becomes generic
+# over FieldBackend.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ACH="$REPO_ROOT/target/release/ach"
+
+# Build once
+echo "Building ach (release)..."
+cargo build --release --manifest-path="$REPO_ROOT/Cargo.toml" 2>/dev/null
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        echo "  PASS  $name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$name")
+        echo "  FAIL  $name"
+    fi
+}
+
+run_fail_test() {
+    local name="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$name (expected failure but succeeded)")
+        echo "  FAIL  $name"
+    else
+        PASS=$((PASS + 1))
+        echo "  PASS  $name"
+    fi
+}
+
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+# ============================================================================
+# BLS12-381 + R1CS -- Circuit tests (constraint generation + witness)
+# Excludes: poseidon, merkle, hash_chain, commitment, nullifier, secret_vote
+# Excludes: division (field inverse), comparison_ops (uses !=)
+# ============================================================================
+
+echo ""
+echo "=== BLS12-381 Circuit tests (R1CS) ==="
+
+run_test "bls12-381/circuit/basic_arithmetic" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/basic_arithmetic.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_basic.r1cs" --wtns "$TMP_DIR/bls_basic.wtns" \
+    --inputs "out=42,a=6,b=7"
+
+run_test "bls12-381/circuit/mux" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/mux.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_mux.r1cs" --wtns "$TMP_DIR/bls_mux.wtns" \
+    --inputs "out=42,cond=1,a=42,b=99"
+
+run_test "bls12-381/circuit/boolean_ops" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/boolean_ops.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_bool.r1cs" --wtns "$TMP_DIR/bls_bool.wtns" \
+    --inputs "x=3,y=5"
+
+run_test "bls12-381/circuit/range_check" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/range_check.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_range.r1cs" --wtns "$TMP_DIR/bls_range.wtns" \
+    --inputs "x=200,y=65000"
+
+run_test "bls12-381/circuit/power" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/power.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_pow.r1cs" --wtns "$TMP_DIR/bls_pow.wtns" \
+    --inputs "x=3,x2=9,x3=27,x4=81"
+
+run_test "bls12-381/circuit/nested_functions" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/nested_functions.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_nested_fn.r1cs" --wtns "$TMP_DIR/bls_nested_fn.wtns" \
+    --inputs "result=25,x=3"
+
+run_test "bls12-381/circuit/for_loop_unroll" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/for_loop_unroll.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_for_loop.r1cs" --wtns "$TMP_DIR/bls_for_loop.wtns" \
+    --inputs "total=100,vals_0=10,vals_1=20,vals_2=30,vals_3=40"
+
+run_test "bls12-381/circuit/deep_functions" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/deep_functions.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_deep_fn.r1cs" --wtns "$TMP_DIR/bls_deep_fn.wtns" \
+    --inputs "out=44,a=10"
+
+run_test "bls12-381/circuit/complex_boolean" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/complex_boolean.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_complex_bool.r1cs" --wtns "$TMP_DIR/bls_complex_bool.wtns" \
+    --inputs "a=3,b=7,c=10,d=2,e=1,f=2"
+
+run_test "bls12-381/circuit/nested_loops" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/nested_loops.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_nested_loops.r1cs" --wtns "$TMP_DIR/bls_nested_loops.wtns" \
+    --inputs "out=36"
+
+run_test "bls12-381/circuit/inner_product" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/inner_product.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_inner_product.r1cs" --wtns "$TMP_DIR/bls_inner_product.wtns" \
+    --inputs "out=70,a_0=1,a_1=2,a_2=3,a_3=4,b_0=5,b_1=6,b_2=7,b_3=8"
+
+run_test "bls12-381/circuit/arrays_and_functions" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/arrays_and_functions.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_arr.r1cs" --wtns "$TMP_DIR/bls_arr.wtns" \
+    --inputs "expected_sum=60,vals_0=10,vals_1=20,vals_2=30"
+
+# Typed circuit tests
+run_test "bls12-381/circuit/typed_arithmetic" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_arithmetic.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_typed_arith.r1cs" --wtns "$TMP_DIR/bls_typed_arith.wtns" \
+    --inputs "out=42,a=6,b=7"
+
+run_test "bls12-381/circuit/typed_boolean_ops" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_boolean_ops.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_typed_bool.r1cs" --wtns "$TMP_DIR/bls_typed_bool.wtns" \
+    --inputs "x=3,y=5"
+
+run_test "bls12-381/circuit/typed_mux" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_mux.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_typed_mux.r1cs" --wtns "$TMP_DIR/bls_typed_mux.wtns" \
+    --inputs "out=42,cond=1,a=42,b=99"
+
+run_test "bls12-381/circuit/typed_arrays_and_functions" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/typed_arrays_and_functions.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/bls_typed_arr.r1cs" --wtns "$TMP_DIR/bls_typed_arr.wtns" \
+    --inputs "expected_sum=60,vals_0=10,vals_1=20,vals_2=30"
+
+# ============================================================================
+# BLS12-381 + R1CS -- Prove tests (Groth16 proof generation + verification)
+# Excludes: prove_with_poseidon, prove_chain, prove_secret_vote (Poseidon)
+# Excludes: prove_comparison (uses !=), prove_division (field inverse)
+# ============================================================================
+
+echo ""
+echo "=== BLS12-381 Prove tests (Groth16) ==="
+
+run_test "bls12-381/prove/basic_prove" \
+    "$ACH" run "$SCRIPT_DIR/prove/basic_prove.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_power" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_power.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_capture" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_capture.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_range_check" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_range_check.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_boolean_mux" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_boolean_mux.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_array_sum" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_array_sum.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_assert_message" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_assert_message.ach" --prime bls12-381
+
+run_test "bls12-381/prove/prove_outer_fn" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_outer_fn.ach" --prime bls12-381
+
+run_test "bls12-381/prove/typed_prove" \
+    "$ACH" run "$SCRIPT_DIR/prove/typed_prove.ach" --prime bls12-381
+
+# ============================================================================
+# Validation tests -- unsupported combinations must fail gracefully
+# ============================================================================
+
+echo ""
+echo "=== Validation tests (expected failures) ==="
+
+# BLS12-381 + Plonkish -> not supported (halo2 PSE is BN254-only)
+run_fail_test "bls12-381/plonkish/rejected" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/basic_arithmetic.ach" \
+    --prime bls12-381 --backend plonkish \
+    --r1cs /dev/null --wtns /dev/null \
+    --inputs "out=42,a=6,b=7"
+
+# Goldilocks + R1CS -> not supported (no pairing-friendly prover)
+run_fail_test "goldilocks/r1cs/rejected" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/basic_arithmetic.ach" \
+    --prime goldilocks \
+    --r1cs /dev/null --wtns /dev/null \
+    --inputs "out=42,a=6,b=7"
+
+# Goldilocks + Plonkish -> not supported
+run_fail_test "goldilocks/plonkish/rejected" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/basic_arithmetic.ach" \
+    --prime goldilocks --backend plonkish \
+    --r1cs /dev/null --wtns /dev/null \
+    --inputs "out=42,a=6,b=7"
+
+# Invalid prime name -> rejected
+run_fail_test "invalid-prime/rejected" \
+    "$ACH" run "$SCRIPT_DIR/prove/basic_prove.ach" --prime secp256k1
+
+# BLS12-381 + Solidity -> rejected (EVM is BN254-only)
+run_fail_test "bls12-381/solidity/rejected" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/basic_arithmetic.ach" \
+    --prime bls12-381 \
+    --r1cs "$TMP_DIR/sol_check.r1cs" --wtns "$TMP_DIR/sol_check.wtns" \
+    --solidity "$TMP_DIR/should_not_exist.sol" \
+    --inputs "out=42,a=6,b=7"
+
+# ============================================================================
+# BN254 regression -- verify existing tests still pass with explicit --prime
+# ============================================================================
+
+echo ""
+echo "=== BN254 regression (explicit --prime bn254) ==="
+
+run_test "bn254/circuit/basic_arithmetic" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/basic_arithmetic.ach" \
+    --prime bn254 \
+    --r1cs "$TMP_DIR/bn_basic.r1cs" --wtns "$TMP_DIR/bn_basic.wtns" \
+    --inputs "out=42,a=6,b=7"
+
+run_test "bn254/prove/basic_prove" \
+    "$ACH" run "$SCRIPT_DIR/prove/basic_prove.ach" --prime bn254
+
+# Poseidon works with explicit BN254 flag
+run_test "bn254/circuit/poseidon" \
+    "$ACH" circuit "$SCRIPT_DIR/circuit/poseidon.ach" \
+    --prime bn254 \
+    --r1cs "$TMP_DIR/bn_poseidon.r1cs" --wtns "$TMP_DIR/bn_poseidon.wtns" \
+    --inputs "expected=7853200120776062878684798364095072458815029376092732009249414926327459813530,a=1,b=2,c=3"
+
+run_test "bn254/prove/prove_with_poseidon" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_with_poseidon.ach" --prime bn254
+
+# Division and comparison work on BN254 (field-native arithmetic)
+run_test "bn254/prove/prove_division" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_division.ach" --prime bn254
+
+run_test "bn254/prove/prove_comparison" \
+    "$ACH" run "$SCRIPT_DIR/prove/prove_comparison.ach" --prime bn254
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+TOTAL=$((PASS + FAIL))
+echo "Cross-prime results: $PASS passed, $FAIL failed (out of $TOTAL)"
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "Failed tests:"
+    for e in "${ERRORS[@]}"; do
+        echo "  - $e"
+    done
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- **Cross-prime test script** (`test/cross_prime_tests.sh`): 36 tests exercising BLS12-381 R1CS circuits, Groth16 proofs, validation of unsupported combos, and BN254 regression
- **Fix: dynamic range bits** — `POWERS_OF_TWO` extended to 256 entries, `enforce_252_range` replaced with `enforce_default_range` using `prime_id.modulus_bit_size() - 2` (BN254→252, BLS12-381→253)
- **Fix: cross-field `fe_to_ark`** — negative coefficients (e.g., `-1` stored as `p_bn254 - 1`) are now correctly converted to the target field's negation instead of being interpreted as a huge positive integer
- **Thread `prime_id`** to `R1CSCompiler` in prove and circuit CLI paths

## Known limitations (tracked)

- Poseidon hardcoded to BN254 (#83)
- Field inverses incompatible cross-prime: `/`, `!=`, `assert(x==y)` (#84)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — 0 failures
- [x] `test/run_tests.sh` — 162/162 pass (BN254 regression)
- [x] `test/cross_prime_tests.sh` — 36/36 pass (BLS12-381 matrix)