### PR TITLE
chore(release): prepare core 0.0.1

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -1,9 +1,20 @@
 name: Set up LLVM 21
 description: Resolve a Clang 21 executable and expose it as clang
 
+inputs:
+  install:
+    description: Install LLVM 21 from apt.llvm.org when it is unavailable
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
+    - name: Install LLVM 21
+      if: inputs.install == 'true'
+      shell: bash
+      run: bash .github/scripts/install-llvm-21.sh
+
     - name: Verify LLVM toolchain
       shell: bash
       run: |

--- a/.github/scripts/install-llvm-21.sh
+++ b/.github/scripts/install-llvm-21.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v clang-21 >/dev/null; then
+    version="$(clang-21 --version | sed -n '1p')"
+    if [[ "$version" == *"clang version 21."* ]]; then
+        echo "$version"
+        exit 0
+    fi
+fi
+
+if [[ ! -r /etc/os-release ]] || ! command -v apt-get >/dev/null; then
+    echo "Automatic LLVM 21 installation requires Debian or Ubuntu" >&2
+    exit 1
+fi
+
+version_codename="$(
+    sed -n 's/^VERSION_CODENAME=//p' /etc/os-release | tr -d '"'
+)"
+case "$version_codename" in
+    noble|jammy) codename="$version_codename" ;;
+    *)
+        echo "Unsupported apt.llvm.org distribution: ${version_codename:-unknown}" >&2
+        exit 1
+        ;;
+esac
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends ca-certificates curl gnupg
+
+temporary_root="$(mktemp -d "${RUNNER_TEMP:-/tmp}/akron-llvm-key.XXXXXX")"
+trap 'rm -rf "$temporary_root"' EXIT
+key_source="$temporary_root/llvm-snapshot.gpg.key"
+keyring="$temporary_root/llvm-snapshot.gpg"
+expected_fingerprint="6084F3CF814B57C1CF12EFD515CF4D18AF4F7421"
+
+curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key -o "$key_source"
+fingerprint="$(
+    gpg --show-keys --with-colons --import-options show-only "$key_source" 2>/dev/null |
+        awk -F: '$1 == "fpr" { print $10; exit }'
+)"
+if [[ "$fingerprint" != "$expected_fingerprint" ]]; then
+    echo "Unexpected apt.llvm.org signing key fingerprint: $fingerprint" >&2
+    exit 1
+fi
+
+gpg --dearmor < "$key_source" > "$keyring"
+sudo install -Dm644 "$keyring" /usr/share/keyrings/apt.llvm.org.gpg
+printf '%s\n' \
+    "deb [signed-by=/usr/share/keyrings/apt.llvm.org.gpg] https://apt.llvm.org/$codename/ llvm-toolchain-$codename-21 main" |
+    sudo tee /etc/apt/sources.list.d/apt.llvm.org.list >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends clang-21 llvm-21
+clang-21 --version | sed -n '1p'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
     branches: [main]
 
@@ -51,44 +51,5 @@ jobs:
         run: bash test/run_tests.sh
 
   llvm:
-    name: LLVM 21 JIT and AOT
-    runs-on: self-hosted
-    concurrency:
-      group: ci-llvm-self-hosted
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Ensure a Rust toolchain is on PATH
-        uses: ./.github/actions/setup-rust
-
-      - name: Ensure LLVM 21 tools are on PATH
-        uses: ./.github/actions/setup-llvm
-
-      - name: Build AOT runtimes
-        run: |
-          cargo build -p akron-aot-runtime
-          cargo build -p akron-aot-runtime --release
-
-      - name: Verify release panic contract
-        run: bash test/release_panic_contract.sh
-
-      - name: Verify LLVM link contract
-        run: bash test/llvm_link_contract.sh
-
-      - name: Verify interpreter-only CLI
-        run: |
-          cargo test -p cli --no-default-features --lib
-          cargo test -p cli --no-default-features \
-            --test default_feature_contract \
-            --test engine_feature_gate_test
-
-      - name: Test LLVM backend
-        run: cargo test -p akron-llvm --features llvm,aot
-
-      - name: Test LLVM CLI engines
-        run: >-
-          cargo test -p cli
-          --test llvm_engine_test
-          --test engine_oracle
-          --test aot_cli_test
+    name: LLVM production gate
+    uses: ./.github/workflows/llvm-production-gate.yml

--- a/.github/workflows/llvm-production-gate.yml
+++ b/.github/workflows/llvm-production-gate.yml
@@ -1,0 +1,35 @@
+name: LLVM Production Gate
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  llvm:
+    name: Linux ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            os: ubuntu-24.04
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.96.0
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.96.0
+
+      - name: Install LLVM 21
+        uses: ./.github/actions/setup-llvm
+        with:
+          install: "true"
+
+      - name: Run LLVM production gate
+        run: bash test/llvm_production_gate.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,41 +8,45 @@ permissions:
   contents: write
 
 jobs:
+  gate:
+    name: LLVM production gate
+    uses: ./.github/workflows/llvm-production-gate.yml
+
   build:
     name: Build (${{ matrix.target }})
+    needs: gate
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
             artifact: achronyme-linux-x86_64
+            upload: dist/*
             pgo: true
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             artifact: achronyme-linux-aarch64
+            upload: dist/*
             pgo: false
           - target: x86_64-apple-darwin
             os: macos-latest
             artifact: achronyme-macos-x86_64
+            upload: achronyme-macos-x86_64
             pgo: false
           - target: aarch64-apple-darwin
             os: macos-latest
             artifact: achronyme-macos-aarch64
+            upload: achronyme-macos-aarch64
             pgo: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: achronyme-windows-x86_64.exe
+            upload: achronyme-windows-x86_64.exe
             pgo: true
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -50,11 +54,15 @@ jobs:
           targets: ${{ matrix.target }}
           components: llvm-tools
 
+      - name: Install LLVM 21
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-llvm
+        with:
+          install: "true"
+
       - name: Build with PGO
         if: matrix.pgo
         shell: bash
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: |
           set -euo pipefail
           SYSROOT="$(rustc --print sysroot)"
@@ -105,12 +113,26 @@ jobs:
 
       - name: Build without PGO
         if: "!matrix.pgo"
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build -p cli --release --target ${{ matrix.target }}
 
-      - name: Rename binary (unix)
-        if: runner.os != 'Windows'
+      - name: Build Linux AOT runtime
+        if: runner.os == 'Linux'
+        run: >-
+          cargo build -p akron-aot-runtime --release
+          --target ${{ matrix.target }}
+
+      - name: Package Linux bundle
+        if: runner.os == 'Linux'
+        run: |
+          scripts/package-release.sh \
+            --target "${{ matrix.target }}" \
+            --name "${{ matrix.artifact }}" \
+            --binary "target/${{ matrix.target }}/release/ach" \
+            --runtime "target/${{ matrix.target }}/release/libakron_aot_runtime.a" \
+            --output dist
+
+      - name: Rename binary (macOS)
+        if: runner.os == 'macOS'
         run: |
           mv target/${{ matrix.target }}/release/ach ${{ matrix.artifact }}
           chmod +x ${{ matrix.artifact }}
@@ -123,7 +145,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
+          path: ${{ matrix.upload }}
 
   release:
     name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags: ["v*"]
 
@@ -8,8 +9,30 @@ permissions:
   contents: write
 
 jobs:
+  metadata:
+    name: Verify release metadata
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate workspace version and tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(sed -n 's/^version = "\([0-9][0-9.]*\)"/\1/p' Cargo.toml | head -1)"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::workspace version is not plain MAJOR.MINOR.PATCH: $VERSION"
+            exit 1
+          fi
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" != "v$VERSION" ]]; then
+            echo "::error::tag ${GITHUB_REF_NAME} does not match workspace version v$VERSION"
+            exit 1
+          fi
+          echo "Release version: $VERSION"
+
   gate:
     name: LLVM production gate
+    needs: metadata
     uses: ./.github/workflows/llvm-production-gate.yml
 
   build:
@@ -51,6 +74,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.96.0
           targets: ${{ matrix.target }}
           components: llvm-tools
 
@@ -150,6 +174,7 @@ jobs:
   release:
     name: Create Release
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to the Achronyme language and CLI are recorded here.
+
+## [0.0.1] - Unreleased
+
+This release starts plain `MAJOR.MINOR.PATCH` numbering for the pre-1.0 line.
+It intentionally follows the historical `0.1.0-beta.22` series as a numbering
+reset. The `0.x` API and language remain subject to change between minor
+versions.
+
+### Added
+
+- LLVM 21 ORC JIT execution in the default CLI, with explicit interpreter
+  selection and visible fallback when LLVM is unavailable.
+- Native AOT compilation with packaged `libakron_aot_runtime.a` discovery.
+- Reproducible Linux release bundles with licenses and SHA-256 checksums.
+- A production gate for Linux x86_64 and aarch64 covering JIT, fallback, AOT,
+  resource limits, file I/O, installed-layout execution, and lazy LLVM loading.
+
+### Compatibility
+
+- Linux GNU x86_64 and aarch64 are the native LLVM release-gated targets.
+- macOS and Windows retain interpreter fallback and are not certified by the
+  Linux native gate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ach-macros"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13,14 +13,14 @@ dependencies = [
 
 [[package]]
 name = "achronyme-parser"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "diagnostics",
 ]
 
 [[package]]
 name = "achronyme-std"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "ach-macros",
  "akron",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "akron"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "ach-macros",
  "akronc",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "akron-aot-runtime"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-std",
  "akron",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "akron-llvm"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "akron",
  "libloading",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "akronc"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-parser",
  "akron",
@@ -426,7 +426,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artik"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "memory",
  "num-bigint",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "circom"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "akron",
  "akronc",
@@ -694,7 +694,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-parser",
  "achronyme-std",
@@ -740,7 +740,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "constraints"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "akronc",
  "ir",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "diagnostics"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 
 [[package]]
 name = "digest"
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "ir"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-parser",
  "artik",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "ir-core"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "diagnostics",
  "memory",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "ir-forge"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-parser",
  "bincode",
@@ -1402,7 +1402,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lysis"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "artik",
  "criterion",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "lysis-types"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "memory",
 ]
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "memory"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "criterion",
  "num-bigint",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "prove-engine"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "akron",
  "artik",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "proving"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "akron",
  "akronc",
@@ -1929,7 +1929,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resolve"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-parser",
 ]
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "zkc"
-version = "0.1.0-beta.22"
+version = "0.0.1"
 dependencies = [
  "achronyme-parser",
  "akronc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-beta.22"
+version = "0.0.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/achronyme/achronyme"

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,7 +1,7 @@
 # Achronyme: Estrategia Técnica y de Mercado
 
 > Última actualización: Junio 2026
-> Estado: v0.1.0-beta.22 — 2,000+ tests (cross-validados con snarkjs), 2 backends con provers nativos Rust, 2 auditorías criptográficas limpias, pipeline E2E funcional, interoperabilidad Groth16 verificada. Imports/módulos, multi-curva (`FieldBackend`: BN254 / BLS12-381 / Goldilocks) y comparaciones acotadas a paridad con Circom ya están en `main`; los únicos bloqueadores reales que faltan para un v1.0 estable son la honestidad del trusted-setup y la fachada de SDK pública.
+> Estado: v0.0.1 en preparacion - 2,000+ tests (cross-validados con snarkjs), 2 backends con provers nativos Rust, 2 auditorías criptográficas limpias, pipeline E2E funcional, interoperabilidad Groth16 verificada. Imports/módulos, multi-curva (`FieldBackend`: BN254 / BLS12-381 / Goldilocks) y comparaciones acotadas a paridad con Circom ya están en `main`; los únicos bloqueadores reales que faltan para un v1.0 estable son la honestidad del trusted-setup y la fachada de SDK pública.
 
 ---
 

--- a/akron-llvm/README.md
+++ b/akron-llvm/README.md
@@ -18,6 +18,23 @@ An executable emitted by the AOT backend also does not link LLVM. Compilation
 requires Clang 21 and the Akron AOT runtime archive, but the generated
 executable contains the native program and runtime.
 
+## Production release gate
+
+Run `bash test/llvm_production_gate.sh` on Linux x86_64 or aarch64. The gate
+checks the interpreter rollback, JIT and AOT parity suites, resource limits,
+the panic and lazy-link contracts, and a release bundle extracted outside the
+repository. The installed-layout smoke requires native JIT execution, visible
+fallback when LLVM is absent, AOT runtime discovery without a workspace path,
+and native file I/O without interpreter bailout.
+
+`.github/workflows/llvm-production-gate.yml` runs the same gate on ephemeral
+Ubuntu x86_64 and aarch64 runners. CI and tag-based releases both call that
+workflow. Linux release archives contain `bin/ach`,
+`lib/libakron_aot_runtime.a`, licenses, and a detached SHA-256 checksum.
+
+This gate certifies the Linux GNU targets listed above. Other release targets
+retain interpreter fallback but are not certified here for native LLVM.
+
 ## JIT object cache
 
 The persistent cache is enabled by default when a platform cache directory can

--- a/cli/tests/release_version_contract.rs
+++ b/cli/tests/release_version_contract.rs
@@ -1,0 +1,8 @@
+#[test]
+fn release_version_is_0_0_1_without_a_prerelease_suffix() {
+    let version = env!("CARGO_PKG_VERSION");
+
+    assert_eq!(version, "0.0.1");
+    assert_eq!(version.split('.').count(), 3);
+    assert!(version.split('.').all(|part| part.parse::<u64>().is_ok()));
+}

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --target TARGET [--name NAME] --binary PATH --runtime PATH --output DIRECTORY" >&2
+}
+
+target=""
+bundle_name=""
+binary=""
+runtime=""
+output_root=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target)
+            target="${2:-}"
+            shift 2
+            ;;
+        --binary)
+            binary="${2:-}"
+            shift 2
+            ;;
+        --name)
+            bundle_name="${2:-}"
+            shift 2
+            ;;
+        --runtime)
+            runtime="${2:-}"
+            shift 2
+            ;;
+        --output)
+            output_root="${2:-}"
+            shift 2
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$target" || -z "$binary" || -z "$runtime" || -z "$output_root" ]]; then
+    usage
+    exit 2
+fi
+if [[ ! "$target" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid target name: $target" >&2
+    exit 2
+fi
+if [[ -n "$bundle_name" && ! "$bundle_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid bundle name: $bundle_name" >&2
+    exit 2
+fi
+if [[ "$target" != *-unknown-linux-gnu ]]; then
+    echo "Release bundles with AOT support currently require a Linux GNU target" >&2
+    exit 2
+fi
+if [[ ! -x "$binary" ]]; then
+    echo "Release binary is missing or not executable: $binary" >&2
+    exit 1
+fi
+if [[ ! -f "$runtime" ]]; then
+    echo "AOT runtime archive is missing: $runtime" >&2
+    exit 1
+fi
+
+for command_name in gzip install sha256sum tar; do
+    command -v "$command_name" >/dev/null
+done
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+bundle="${bundle_name:-achronyme-$target}"
+archive_name="$bundle.tar.gz"
+mkdir -p "$output_root"
+staging_root="$(mktemp -d "$output_root/.${bundle}.XXXXXX")"
+
+cleanup() {
+    rm -rf -- "$staging_root"
+}
+trap cleanup EXIT
+
+bundle_root="$staging_root/$bundle"
+install -Dm755 "$binary" "$bundle_root/bin/ach"
+install -Dm644 "$runtime" "$bundle_root/lib/libakron_aot_runtime.a"
+install -Dm644 "$repository_root/LICENSE" "$bundle_root/LICENSE"
+install -Dm644 "$repository_root/NOTICE" "$bundle_root/NOTICE"
+install -Dm644 "$repository_root/README.md" "$bundle_root/README.md"
+
+archive_temp="$staging_root/$archive_name"
+tar \
+    --sort=name \
+    --mtime='UTC 1970-01-01' \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    -C "$staging_root" \
+    -cf - "$bundle" | gzip -n > "$archive_temp"
+
+checksum="$(sha256sum "$archive_temp" | cut -d ' ' -f 1)"
+checksum_temp="$staging_root/$archive_name.sha256"
+printf '%s  %s\n' "$checksum" "$archive_name" > "$checksum_temp"
+
+install -m 0644 "$archive_temp" "$output_root/$archive_name"
+install -m 0644 "$checksum_temp" "$output_root/$archive_name.sha256"
+
+echo "$output_root/$archive_name"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -103,5 +103,6 @@ printf '%s  %s\n' "$checksum" "$archive_name" > "$checksum_temp"
 
 install -m 0644 "$archive_temp" "$output_root/$archive_name"
 install -m 0644 "$checksum_temp" "$output_root/$archive_name.sha256"
+install -m 0755 "$binary" "$output_root/$bundle"
 
 echo "$output_root/$archive_name"

--- a/test/llvm_production_gate.sh
+++ b/test/llvm_production_gate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "LLVM production gate requires Linux" >&2
+    exit 1
+fi
+
+case "$(uname -m)" in
+    x86_64)
+        target="x86_64-unknown-linux-gnu"
+        bundle="achronyme-linux-x86_64"
+        ;;
+    aarch64)
+        target="aarch64-unknown-linux-gnu"
+        bundle="achronyme-linux-aarch64"
+        ;;
+    *)
+        echo "Unsupported LLVM production gate architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repository_root"
+
+for command_name in cargo clang file readelf rustc sha256sum tar; do
+    command -v "$command_name" >/dev/null
+done
+
+clang_version="$(clang --version | sed -n '1p')"
+clang_major="$(
+    printf '%s\n' "$clang_version" |
+        sed -n 's/.*clang version \([0-9][0-9]*\).*/\1/p'
+)"
+if [[ "$clang_major" != "21" ]]; then
+    echo "LLVM production gate requires Clang 21, found: $clang_version" >&2
+    exit 1
+fi
+
+echo "Gate host: $(uname -s) $(uname -m)"
+echo "Gate Rust: $(rustc --version)"
+echo "Gate Clang: $clang_version"
+
+bash test/release_bundle_contract.sh
+cargo build -p akron-aot-runtime
+bash test/release_panic_contract.sh
+bash test/llvm_link_contract.sh
+
+cargo test -p cli --no-default-features --lib
+cargo test -p cli --no-default-features \
+    --test default_feature_contract \
+    --test engine_feature_gate_test
+cargo test -p akron-llvm --features llvm,aot
+cargo test -p cli \
+    --test llvm_engine_test \
+    --test engine_oracle \
+    --test aot_cli_test
+
+cargo build --release -p cli -p akron-aot-runtime
+
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/akron-llvm-production-gate.XXXXXX")"
+trap 'rm -rf "$temporary_root"' EXIT
+package_root="$temporary_root/package"
+install_root="$temporary_root/install"
+smoke_root="$temporary_root/smoke"
+mkdir -p "$package_root" "$install_root" "$smoke_root"
+
+scripts/package-release.sh \
+    --target "$target" \
+    --name "$bundle" \
+    --binary "target/release/ach" \
+    --runtime "target/release/libakron_aot_runtime.a" \
+    --output "$package_root"
+
+archive_name="$bundle.tar.gz"
+(cd "$package_root" && sha256sum --check "$archive_name.sha256")
+tar -xzf "$package_root/$archive_name" -C "$install_root"
+installed_root="$install_root/$bundle"
+ach="$installed_root/bin/ach"
+
+if readelf -d "$ach" | grep -Eq 'NEEDED.*libLLVM'; then
+    echo "Installed ach must load LLVM lazily" >&2
+    exit 1
+fi
+
+printf 'return 6 * 7\n' > "$smoke_root/scalar.ach"
+printf '%s\n' \
+    'let path = read_line()' \
+    'write_file(path, "akron-installed-io")' \
+    'let content = read_file(path)' \
+    'assert(content == "akron-installed-io")' \
+    'print(content)' > "$smoke_root/io.ach"
+
+(
+    cd "$smoke_root"
+    AKRON_ENGINE_TRACE=1 AKRON_JIT_CACHE=0 \
+        "$ach" --no-config run scalar.ach --engine jit \
+        > jit.stdout 2> jit.stderr
+)
+grep -q 'LLVM JIT native:' "$smoke_root/jit.stderr"
+grep -q 'Exit Status: 42' "$smoke_root/jit.stdout"
+
+(
+    cd "$smoke_root"
+    AKRON_LLVM_DYLIB="$smoke_root/missing-libLLVM.so" \
+        "$ach" --no-config run scalar.ach \
+        > fallback.stdout 2> fallback.stderr
+)
+grep -q 'LLVM JIT fallback:' "$smoke_root/fallback.stderr"
+grep -q 'Exit Status: 42' "$smoke_root/fallback.stdout"
+
+(
+    cd "$smoke_root"
+    env -u AKRON_AOT_RUNTIME_ARCHIVE \
+        "$ach" --no-config aot scalar.ach --output scalar-native \
+        > aot-build.stdout 2> aot-build.stderr
+)
+native_count="$(
+    sed -n 's/.*(\([0-9][0-9]*\)\/\([0-9][0-9]*\) bytecode.*/\1/p' \
+        "$smoke_root/aot-build.stdout"
+)"
+instruction_count="$(
+    sed -n 's/.*(\([0-9][0-9]*\)\/\([0-9][0-9]*\) bytecode.*/\2/p' \
+        "$smoke_root/aot-build.stdout"
+)"
+if [[ -z "$native_count" || -z "$instruction_count" || "$native_count" -eq 0 ]]; then
+    echo "AOT scalar smoke did not report native lowering" >&2
+    cat "$smoke_root/aot-build.stdout" >&2
+    exit 1
+fi
+AKRON_ENGINE_TRACE=1 "$smoke_root/scalar-native" \
+    > "$smoke_root/native.stdout" 2> "$smoke_root/native.stderr"
+grep -q 'Exit Status: 42' "$smoke_root/native.stdout"
+grep -q 'LLVM AOT native: program completed without interpreter bailout' \
+    "$smoke_root/native.stderr"
+
+if readelf -d "$smoke_root/scalar-native" | grep -Eq 'NEEDED.*libLLVM'; then
+    echo "AOT executable must not depend on libLLVM" >&2
+    exit 1
+fi
+
+(
+    cd "$smoke_root"
+    env -u AKRON_AOT_RUNTIME_ARCHIVE \
+        "$ach" --no-config aot io.ach --output io-native \
+        > io-build.stdout 2> io-build.stderr
+    printf '%s\n' "$smoke_root/io-output.txt" | \
+        AKRON_ENGINE_TRACE=1 ./io-native > io.stdout 2> io.stderr
+)
+grep -q 'akron-installed-io' "$smoke_root/io.stdout"
+grep -q 'LLVM AOT native: program completed without interpreter bailout' \
+    "$smoke_root/io.stderr"
+test "$(< "$smoke_root/io-output.txt")" = "akron-installed-io"
+
+file "$ach"
+file "$smoke_root/scalar-native"
+echo "LLVM production gate passed on $target"

--- a/test/release_bundle_contract.sh
+++ b/test/release_bundle_contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/achronyme-release-bundle.XXXXXX")"
+trap 'rm -rf "$temporary_root"' EXIT
+
+fixture_root="$temporary_root/fixtures"
+output_root="$temporary_root/output"
+repeat_output_root="$temporary_root/repeat-output"
+install_root="$temporary_root/install"
+target="x86_64-unknown-linux-gnu"
+bundle="achronyme-linux-x86_64"
+archive="$output_root/$bundle.tar.gz"
+
+mkdir -p "$fixture_root" "$output_root" "$repeat_output_root" "$install_root"
+printf '#!/usr/bin/env bash\nprintf "installed-ach\\n"\n' > "$fixture_root/ach"
+chmod +x "$fixture_root/ach"
+printf 'runtime-archive\n' > "$fixture_root/libakron_aot_runtime.a"
+
+"$repository_root/scripts/package-release.sh" \
+    --target "$target" \
+    --name "$bundle" \
+    --binary "$fixture_root/ach" \
+    --runtime "$fixture_root/libakron_aot_runtime.a" \
+    --output "$output_root"
+"$repository_root/scripts/package-release.sh" \
+    --target "$target" \
+    --name "$bundle" \
+    --binary "$fixture_root/ach" \
+    --runtime "$fixture_root/libakron_aot_runtime.a" \
+    --output "$repeat_output_root"
+
+test -f "$archive"
+test -f "$archive.sha256"
+cmp "$archive" "$repeat_output_root/$bundle.tar.gz"
+cmp "$archive.sha256" "$repeat_output_root/$bundle.tar.gz.sha256"
+(cd "$output_root" && sha256sum --check "$(basename "$archive.sha256")")
+tar -xzf "$archive" -C "$install_root"
+
+test -x "$install_root/$bundle/bin/ach"
+test -f "$install_root/$bundle/lib/libakron_aot_runtime.a"
+test -f "$install_root/$bundle/LICENSE"
+test -f "$install_root/$bundle/NOTICE"
+test "$("$install_root/$bundle/bin/ach")" = "installed-ach"
+cmp "$fixture_root/libakron_aot_runtime.a" \
+    "$install_root/$bundle/lib/libakron_aot_runtime.a"
+
+echo "release bundle contract verified: executable, AOT runtime, licenses, and checksum"

--- a/test/release_bundle_contract.sh
+++ b/test/release_bundle_contract.sh
@@ -12,6 +12,7 @@ install_root="$temporary_root/install"
 target="x86_64-unknown-linux-gnu"
 bundle="achronyme-linux-x86_64"
 archive="$output_root/$bundle.tar.gz"
+legacy_binary="$output_root/$bundle"
 
 mkdir -p "$fixture_root" "$output_root" "$repeat_output_root" "$install_root"
 printf '#!/usr/bin/env bash\nprintf "installed-ach\\n"\n' > "$fixture_root/ach"
@@ -33,6 +34,9 @@ printf 'runtime-archive\n' > "$fixture_root/libakron_aot_runtime.a"
 
 test -f "$archive"
 test -f "$archive.sha256"
+test -x "$legacy_binary"
+cmp "$fixture_root/ach" "$legacy_binary"
+cmp "$legacy_binary" "$repeat_output_root/$bundle"
 cmp "$archive" "$repeat_output_root/$bundle.tar.gz"
 cmp "$archive.sha256" "$repeat_output_root/$bundle.tar.gz.sha256"
 (cd "$output_root" && sha256sum --check "$(basename "$archive.sha256")")


### PR DESCRIPTION
## Summary

- establish 0.0.1 as the first plain MAJOR.MINOR.PATCH release
- add the LLVM 21 production gate on native x86_64 and ARM64 runners
- package reproducible Linux bundles with checksums, licenses, and the AOT runtime
- keep standalone binaries for the existing platform matrix

## Verification

- CI: https://github.com/achronyme/achronyme/actions/runs/30729425689
- release dry run: https://github.com/achronyme/achronyme/actions/runs/30729790561
- release bundle and version contracts passed
- generated artifacts were downloaded and inspected before integration

## Known boundary

The local single-party trusted setup remains suitable for development and tests only; this release does not claim a production ceremony.