### PR TITLE
docs(release): finalize 0.0.1 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Achronyme language and CLI are recorded here.
 
-## [0.0.1] - Unreleased
+## [0.0.1] - 2026-08-02
 
 This release starts plain `MAJOR.MINOR.PATCH` numbering for the pre-1.0 line.
 It intentionally follows the historical `0.1.0-beta.22` series as a numbering

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,7 +1,7 @@
 # Achronyme: Estrategia Técnica y de Mercado
 
 > Última actualización: Junio 2026
-> Estado: v0.0.1 en preparacion - 2,000+ tests (cross-validados con snarkjs), 2 backends con provers nativos Rust, 2 auditorías criptográficas limpias, pipeline E2E funcional, interoperabilidad Groth16 verificada. Imports/módulos, multi-curva (`FieldBackend`: BN254 / BLS12-381 / Goldilocks) y comparaciones acotadas a paridad con Circom ya están en `main`; los únicos bloqueadores reales que faltan para un v1.0 estable son la honestidad del trusted-setup y la fachada de SDK pública.
+> Estado: v0.0.1 - 2,000+ tests (cross-validados con snarkjs), 2 backends con provers nativos Rust, 2 auditorías criptográficas limpias, pipeline E2E funcional, interoperabilidad Groth16 verificada. Imports/módulos, multi-curva (`FieldBackend`: BN254 / BLS12-381 / Goldilocks) y comparaciones acotadas a paridad con Circom ya están en `main`; los únicos bloqueadores reales que faltan para un v1.0 estable son la honestidad del trusted-setup y la fachada de SDK pública.
 
 ---
 


### PR DESCRIPTION
## Summary

- date the 0.0.1 changelog entry for the public release
- remove the preparation qualifier from the current strategy status

## Verification

- cargo test -p cli --test release_version_contract
- git diff --check