### PR TITLE
fix(core): mature module, proving, stats, and runtime contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the Achronyme language and CLI are recorded here.
 
+## [0.1.1] - 2026-08-08
+
+### Added
+
+- A versioned Tilino Lab end-to-end fixture covering namespace modules, typed
+  array captures, interpreter and LLVM JIT parity, structured concurrency,
+  explicit capabilities, Groth16 generation, detached verification, tampered
+  public inputs, resource exhaustion, and the standalone AOT boundary.
+
+### Fixed
+
+- Module parse errors, compile errors, and warnings now retain the canonical
+  imported file, exact span, and matching source text in human, JSON, and
+  short diagnostics.
+- Prove blocks inside imported functions now begin resolver lookup in the
+  function's owning module, so typed array captures resolve and count as reads.
+- Circuit statistics distinguish the pre-R1CS-optimization estimate from the
+  exact finalized R1CS constraint count used for Groth16 proving.
+- `max_tasks` consistently counts explicit and implicit live child tasks, and
+  `max_task_scopes` consistently counts all simultaneously live structured
+  scopes instead of being described as nesting depth.
+
+### Compatibility
+
+- ACHB container format, bytecode version, runtime ABI, trusted-key format,
+  and fail-closed proving policy are unchanged from 0.1.0.
+
 ## [0.1.0] - 2026-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ach-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13,14 +13,14 @@ dependencies = [
 
 [[package]]
 name = "achronyme-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "diagnostics",
 ]
 
 [[package]]
 name = "achronyme-std"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ach-macros",
  "akron",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "akron"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ach-macros",
  "akronc",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "akron-aot-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-std",
  "akron",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "akron-llvm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "akron",
  "libloading",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "akronc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-parser",
  "akron",
@@ -646,7 +646,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artik"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "memory",
  "num-bigint",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "circom"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "akron",
  "akronc",
@@ -964,7 +964,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-parser",
  "achronyme-std",
@@ -1033,7 +1033,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "constraints"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "akronc",
  "ir",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "diagnostics"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "digest"
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "ir"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-parser",
  "artik",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "ir-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "diagnostics",
  "memory",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "ir-forge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-parser",
  "bincode",
@@ -1838,7 +1838,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lysis"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "artik",
  "criterion",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "lysis-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "memory",
 ]
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "memory"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "num-bigint",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "prove-engine"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "akron",
  "artik",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "proving"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "akron",
  "akronc",
@@ -2473,7 +2473,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resolve"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-parser",
 ]
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "zkc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "achronyme-parser",
  "akronc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/achronyme/achronyme"

--- a/akron/src/machine/limits.rs
+++ b/akron/src/machine/limits.rs
@@ -9,8 +9,10 @@ use super::VM;
 /// Per-VM bounds for structured concurrency and owned host state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RuntimeLimits {
+    /// Maximum live child tasks across explicit spawn and implicit await.
     pub max_tasks: usize,
     pub max_resources: usize,
+    /// Maximum simultaneously live structured task scopes across the VM.
     pub max_task_scopes: usize,
     pub max_pending_native_requests: usize,
     pub max_retained_task_results: usize,

--- a/akron/src/machine/task/spawn.rs
+++ b/akron/src/machine/task/spawn.rs
@@ -12,7 +12,7 @@ impl VM {
     pub(super) fn enter_task_scope(&mut self) -> Result<(), RuntimeError> {
         if self.task_scheduler.scopes.len() >= self.runtime_limits.max_task_scopes {
             return Err(RuntimeError::resource_limit_exceeded(format!(
-                "nested task scopes exceed {}",
+                "live task scopes exceed {}",
                 self.runtime_limits.max_task_scopes
             )));
         }
@@ -50,7 +50,7 @@ impl VM {
             .ok_or(RuntimeError::TaskOutOfScope)?;
         if self.task_scheduler.tasks.len() >= self.runtime_limits.max_tasks {
             return Err(RuntimeError::resource_limit_exceeded(format!(
-                "live task count exceeds {}",
+                "live child task count exceeds {}",
                 self.runtime_limits.max_tasks
             )));
         }

--- a/akron/tests/structured_concurrency_test.rs
+++ b/akron/tests/structured_concurrency_test.rs
@@ -171,7 +171,61 @@ fn configured_live_task_limit_is_a_hard_bound() {
 
     let error = vm.interpret().unwrap_err();
     assert!(
-        error.to_string().contains("live task count exceeds 1"),
+        error
+            .to_string()
+            .contains("live child task count exceeds 1"),
+        "{error}"
+    );
+}
+
+#[test]
+fn configured_task_limit_counts_explicit_and_implicit_children() {
+    let _pool_guard = lock_async_pool_test();
+    let mut vm = loaded_async_vm(
+        "fn wait_once() { await delay() }\n\
+         concurrent {\n\
+             let first = spawn wait_once();\n\
+             let second = spawn wait_once();\n\
+             await first;\n\
+             await second\n\
+         }",
+        "delay",
+        start_delay,
+    );
+    let mut limits = vm.runtime_limits;
+    limits.max_tasks = 2;
+    vm.set_runtime_limits(limits).unwrap();
+
+    let error = vm.interpret().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("live child task count exceeds 2"),
+        "{error}"
+    );
+}
+
+#[test]
+fn configured_task_scope_limit_counts_simultaneously_live_scopes() {
+    let _pool_guard = lock_async_pool_test();
+    let mut vm = loaded_async_vm(
+        "fn wait_once() { await delay() }\n\
+         concurrent {\n\
+             let first = spawn wait_once();\n\
+             let second = spawn wait_once();\n\
+             await first;\n\
+             await second\n\
+         }",
+        "delay",
+        start_delay,
+    );
+    let mut limits = vm.runtime_limits;
+    limits.max_task_scopes = 2;
+    vm.set_runtime_limits(limits).unwrap();
+
+    let error = vm.interpret().unwrap_err();
+    assert!(
+        error.to_string().contains("live task scopes exceed 2"),
         "{error}"
     );
 }

--- a/akronc/src/codegen/constructors.rs
+++ b/akronc/src/codegen/constructors.rs
@@ -104,6 +104,8 @@ impl Compiler {
             resolver_hits: Vec::new(),
             resolver_dispatch_by_symbol: None,
             resolver_module_by_key: None,
+            resolver_module_by_path: None,
+            resolver_current_module: None,
             resolver_availability_map: None,
         }
     }

--- a/akronc/src/codegen/diagnostics.rs
+++ b/akronc/src/codegen/diagnostics.rs
@@ -12,6 +12,7 @@
 
 use achronyme_parser::diagnostic::SpanRange;
 use achronyme_parser::Diagnostic;
+use std::path::Path;
 
 use super::Compiler;
 use crate::error::{CompilerError, OptSpan};
@@ -30,6 +31,11 @@ impl Compiler {
     /// Take all collected warnings, leaving the internal list empty.
     pub fn take_warnings(&mut self) -> Vec<Diagnostic> {
         std::mem::take(&mut self.warnings)
+    }
+
+    /// Source text for a canonical module path loaded during compilation.
+    pub fn module_source(&self, path: &Path) -> Option<&str> {
+        self.module_loader.source(path)
     }
 
     /// Collect all in-scope names (locals, globals) for "did you mean?" suggestions.

--- a/akronc/src/codegen/mod.rs
+++ b/akronc/src/codegen/mod.rs
@@ -195,6 +195,14 @@ pub struct Compiler {
     /// so a bare identifier in an inlined body resolves against its
     /// own module's symbols.
     pub resolver_module_by_key: Option<Arc<HashMap<String, ModuleId>>>,
+    /// Canonical module path to its owning [`ModuleId`]. Unlike dispatch
+    /// keys, paths also identify selective imports whose compiler-only
+    /// `__sel_N` prefix has no resolver equivalent.
+    pub resolver_module_by_path: Option<Arc<HashMap<PathBuf, ModuleId>>>,
+    /// Resolver module for the module body currently being compiled.
+    /// [`crate::statements::imports`] saves and restores this around nested
+    /// imports so functions inherit the annotation scope of their source file.
+    pub resolver_current_module: Option<ModuleId>,
     // ── Availability inference ─────────────────────────────────────
     /// fn_table key → [`Availability`] for every user function.
     /// The VM compiler checks this before emitting bytecode: if a

--- a/akronc/src/codegen/resolver_state.rs
+++ b/akronc/src/codegen/resolver_state.rs
@@ -50,6 +50,8 @@ impl Compiler {
         self.resolver_hits.clear();
         self.resolver_dispatch_by_symbol = None;
         self.resolver_module_by_key = None;
+        self.resolver_module_by_path = None;
+        self.resolver_current_module = None;
         self.resolver_availability_map = None;
         self.resolver_outer_functions = None;
     }
@@ -129,6 +131,11 @@ impl Compiler {
         // handoff into `OuterResolverState` is a refcount bump
         // rather than a HashMap clone.
         let (dispatch_by_symbol, module_by_key) = build_dispatch_maps(&state.table, &state.graph);
+        let module_by_path = state
+            .graph
+            .iter()
+            .map(|module| (module.path.clone(), module.id))
+            .collect();
         let availability_map = build_availability_map(&state.table, &state.graph);
 
         // Derive outer functions from the graph so prove blocks can
@@ -142,6 +149,8 @@ impl Compiler {
         self.resolver_root_module = Some(root_module);
         self.resolver_dispatch_by_symbol = Some(Arc::new(dispatch_by_symbol));
         self.resolver_module_by_key = Some(Arc::new(module_by_key));
+        self.resolver_module_by_path = Some(Arc::new(module_by_path));
+        self.resolver_current_module = None;
         self.resolver_availability_map = Some(availability_map);
         self.resolver_outer_functions = Some(outer_functions);
         self.inferred_effects = inferred_effects;

--- a/akronc/src/codegen/tests.rs
+++ b/akronc/src/codegen/tests.rs
@@ -54,6 +54,34 @@ mod warning_tests {
     }
 
     #[test]
+    fn array_parameters_used_only_by_prove_are_not_reported_unused() {
+        let ws = compile_warnings(
+            "fn prove_membership(\
+                 root,\
+                 leaf,\
+                 path: Field[2],\
+                 indices: Field[2]\
+             ) {\
+                 prove(root: Public) {\
+                     merkle_verify(root, leaf, path, indices)\
+                 }\
+             }",
+        );
+
+        assert!(
+            !ws.iter().any(|warning| {
+                warning
+                    .message
+                    .contains("unused function parameter: `path`")
+                    || warning
+                        .message
+                        .contains("unused function parameter: `indices`")
+            }),
+            "prove captures must count as parameter reads: {ws:?}"
+        );
+    }
+
+    #[test]
     fn underscore_param_suppresses_warning() {
         let ws = compile_warnings("fn test(_x) { 1 }");
         assert!(!ws

--- a/akronc/src/control_flow/zk.rs
+++ b/akronc/src/control_flow/zk.rs
@@ -118,7 +118,14 @@ pub(super) fn compile_prove(
         ) => Some(ir_forge::OuterResolverState {
             table: std::sync::Arc::new(table.clone()),
             resolved: std::sync::Arc::new(resolved.clone()),
-            root_module,
+            // A prove block embedded in an imported function starts in that
+            // function's module. Falling back to the graph root preserves the
+            // standalone and top-level behavior.
+            root_module: compiler
+                .current_ref()
+                .ok()
+                .and_then(|func| func.resolver_module)
+                .unwrap_or(root_module),
             dispatch_key_by_symbol: dispatch_by_symbol.clone(),
             module_by_dispatch_key: module_by_key.clone(),
             availability_by_key: std::sync::Arc::new(

--- a/akronc/src/error.rs
+++ b/akronc/src/error.rs
@@ -5,6 +5,8 @@ use achronyme_parser::ast::Span;
 use achronyme_parser::diagnostic::SpanRange;
 use achronyme_parser::Diagnostic;
 
+use crate::module_loader::ModuleLoadError;
+
 /// Boxed span to keep error enum small.
 pub type OptSpan = Option<Box<SpanRange>>;
 
@@ -25,7 +27,16 @@ pub enum CompilerError {
     CompileError(String, OptSpan),
     ModuleNotFound(String, OptSpan),
     CircularImport(String, OptSpan),
-    ModuleLoadError(String),
+    ModuleLoadError(ModuleLoadError),
+    /// Error raised while compiling a parsed module.
+    ///
+    /// The nested error retains its structured diagnostic while this wrapper
+    /// provides the canonical path and source text used by CLI rendering.
+    ModuleSource {
+        path: PathBuf,
+        source: String,
+        error: Box<CompilerError>,
+    },
     DuplicateModuleAlias(String, OptSpan),
     InternalError(String),
     /// A rich error that already carries a full Diagnostic (for structured suggestions).
@@ -88,6 +99,7 @@ impl fmt::Display for CompilerError {
                 write!(f, "{}circular import: {path}", fmt_span(span))
             }
             CompilerError::ModuleLoadError(msg) => write!(f, "module load error: {msg}"),
+            CompilerError::ModuleSource { error, .. } => write!(f, "{error}"),
             CompilerError::DuplicateModuleAlias(name, span) => {
                 write!(f, "{}duplicate module alias: {name}", fmt_span(span))
             }
@@ -121,6 +133,14 @@ impl CompilerError {
         // DiagnosticError already carries the full Diagnostic
         if let CompilerError::DiagnosticError(diag) = self {
             return *diag.clone();
+        }
+
+        if let CompilerError::ModuleLoadError(error) = self {
+            return error.to_diagnostic();
+        }
+
+        if let CompilerError::ModuleSource { path, error, .. } = self {
+            return error.to_diagnostic().with_file(path.clone());
         }
 
         // CircomImport renders the .ach import span as the primary
@@ -160,11 +180,23 @@ impl CompilerError {
             | CompilerError::DuplicateModuleAlias(_, s) => s.as_deref().cloned(),
             CompilerError::ParseError(_)
             | CompilerError::ModuleLoadError(_)
+            | CompilerError::ModuleSource { .. }
             | CompilerError::InternalError(_)
             | CompilerError::DiagnosticError(_)
             | CompilerError::CircomImport { .. } => None,
         };
         let primary = span.unwrap_or_else(|| SpanRange::point(0, 0, 0));
         Diagnostic::error(self.to_string(), primary)
+    }
+
+    /// Source text that corresponds to the primary structured diagnostic.
+    pub fn diagnostic_source(&self) -> Option<&str> {
+        match self {
+            CompilerError::ModuleLoadError(error) => error.source(),
+            CompilerError::ModuleSource { source, error, .. } => {
+                error.diagnostic_source().or(Some(source.as_str()))
+            }
+            _ => None,
+        }
     }
 }

--- a/akronc/src/function_compiler.rs
+++ b/akronc/src/function_compiler.rs
@@ -3,11 +3,18 @@ use crate::types::{Local, LoopContext, UpvalueInfo};
 use akron::opcode::instruction::{encode_abc, encode_abx};
 use akron::opcode::OpCode;
 use memory::Value;
+use resolve::ModuleId;
 
 /// State specific to ONE function being compiled
 pub struct FunctionCompiler {
     pub name: String,
     pub arity: u8,
+    /// Resolver module that owns this function body.
+    ///
+    /// Prove blocks use this as their initial annotation scope. Imported
+    /// functions must not start resolution in the program root because AST
+    /// expression ids are local to each module.
+    pub resolver_module: Option<ModuleId>,
     pub locals: Vec<Local>,
     pub scope_depth: u32,
     pub bytecode: Vec<u32>,
@@ -33,6 +40,7 @@ impl FunctionCompiler {
         Self {
             name,
             arity,
+            resolver_module: None,
             locals: Vec::new(),
             scope_depth: 0,
             bytecode: Vec::new(),

--- a/akronc/src/functions.rs
+++ b/akronc/src/functions.rs
@@ -63,19 +63,22 @@ impl FunctionDefinitionCompiler for Compiler {
         // Use the current span (pointing to the fn declaration) for param locals
         let fn_span = self.current_span.clone();
 
-        // Preserve the resolver module that owns this function body. Namespace
-        // imports compile under a mangled `{alias}::{name}` key, which maps
-        // directly to the ModuleId produced by the resolver graph. Lambdas and
+        // Preserve the resolver module that owns this function body. The active
+        // source path covers namespace and selective imports; the dispatch key
+        // remains the fallback for callers without path context. Lambdas and
         // other nested functions inherit the module of their enclosing body.
-        let resolver_module = name
-            .and_then(|declared_name| {
-                let fn_key = match &self.module_prefix {
-                    Some(prefix) => format!("{prefix}::{declared_name}"),
-                    None => declared_name.to_string(),
-                };
-                self.resolver_module_by_key
-                    .as_ref()
-                    .and_then(|modules| modules.get(&fn_key).copied())
+        let resolver_module = self
+            .resolver_current_module
+            .or_else(|| {
+                name.and_then(|declared_name| {
+                    let fn_key = match &self.module_prefix {
+                        Some(prefix) => format!("{prefix}::{declared_name}"),
+                        None => declared_name.to_string(),
+                    };
+                    self.resolver_module_by_key
+                        .as_ref()
+                        .and_then(|modules| modules.get(&fn_key).copied())
+                })
             })
             .or_else(|| {
                 self.current_ref()

--- a/akronc/src/functions.rs
+++ b/akronc/src/functions.rs
@@ -63,8 +63,30 @@ impl FunctionDefinitionCompiler for Compiler {
         // Use the current span (pointing to the fn declaration) for param locals
         let fn_span = self.current_span.clone();
 
-        self.compilers
-            .push(FunctionCompiler::new(fn_name.clone(), arity));
+        // Preserve the resolver module that owns this function body. Namespace
+        // imports compile under a mangled `{alias}::{name}` key, which maps
+        // directly to the ModuleId produced by the resolver graph. Lambdas and
+        // other nested functions inherit the module of their enclosing body.
+        let resolver_module = name
+            .and_then(|declared_name| {
+                let fn_key = match &self.module_prefix {
+                    Some(prefix) => format!("{prefix}::{declared_name}"),
+                    None => declared_name.to_string(),
+                };
+                self.resolver_module_by_key
+                    .as_ref()
+                    .and_then(|modules| modules.get(&fn_key).copied())
+            })
+            .or_else(|| {
+                self.current_ref()
+                    .ok()
+                    .and_then(|func| func.resolver_module)
+            })
+            .or(self.resolver_root_module);
+
+        let mut function_compiler = FunctionCompiler::new(fn_name.clone(), arity);
+        function_compiler.resolver_module = resolver_module;
+        self.compilers.push(function_compiler);
 
         for (i, param) in params.iter().enumerate() {
             self.current()?.locals.push(Local {

--- a/akronc/src/module_loader.rs
+++ b/akronc/src/module_loader.rs
@@ -1,2 +1,2 @@
 // Re-export from ir crate — single source of truth for module loading.
-pub use ir::module_loader::{ModuleExports, ModuleLoader};
+pub use ir::module_loader::{ModuleExports, ModuleLoadError, ModuleLoader};

--- a/akronc/src/statements/imports.rs
+++ b/akronc/src/statements/imports.rs
@@ -23,6 +23,40 @@ use achronyme_parser::ast::*;
 use akron::opcode::OpCode;
 use memory::Value;
 
+fn compile_module_statements(
+    compiler: &mut Compiler,
+    canonical: &Path,
+    source: &str,
+    prefix: &str,
+    statements: &[Stmt],
+) -> Result<(), CompilerError> {
+    compiler.compiling_modules.insert(canonical.to_path_buf());
+
+    let old_prefix = compiler.module_prefix.take();
+    let old_base = compiler.base_path.take();
+    compiler.module_prefix = Some(prefix.to_string());
+    compiler.base_path = canonical.parent().map(|path| path.to_path_buf());
+
+    let warning_start = compiler.warnings.len();
+    let result = statements
+        .iter()
+        .try_for_each(|statement| compiler.compile_stmt(statement));
+
+    for warning in &mut compiler.warnings[warning_start..] {
+        *warning = warning.clone().with_file(canonical.to_path_buf());
+    }
+
+    compiler.module_prefix = old_prefix;
+    compiler.base_path = old_base;
+    compiler.compiling_modules.remove(canonical);
+
+    result.map_err(|error| CompilerError::ModuleSource {
+        path: canonical.to_path_buf(),
+        source: source.to_string(),
+        error: Box::new(error),
+    })
+}
+
 pub(super) fn compile_import(
     compiler: &mut Compiler,
     path: &str,
@@ -80,25 +114,11 @@ pub(super) fn compile_import(
         .map_err(CompilerError::ModuleLoadError)?;
     let module_stmts = module.program.stmts.clone();
     let exported_names = module.exported_names.clone();
+    let module_source = module.source.clone();
 
-    // 5. Mark as compiling (for cycle detection during stmt compilation)
-    compiler.compiling_modules.insert(canonical.clone());
-
-    // 6. Save and set module_prefix + base_path for name mangling
-    let old_prefix = compiler.module_prefix.take();
-    let old_base = compiler.base_path.take();
-    compiler.module_prefix = Some(alias.to_string());
-    compiler.base_path = canonical.parent().map(|p| p.to_path_buf());
-
-    // 7. Compile the module's statements (globals get mangled as alias::name)
-    for stmt in &module_stmts {
-        compiler.compile_stmt(stmt)?;
-    }
-
-    // 8. Restore prefix and base_path, remove from compiling set
-    compiler.module_prefix = old_prefix;
-    compiler.base_path = old_base;
-    compiler.compiling_modules.remove(&canonical);
+    // 5. Compile the module under its namespace while preserving source
+    // context for errors and warnings.
+    compile_module_statements(compiler, &canonical, &module_source, alias, &module_stmts)?;
 
     // 9. Build a Map { export_name: value } and bind it to the alias
     let count = exported_names.len();
@@ -216,6 +236,7 @@ pub(super) fn compile_selective_import(
         .map_err(CompilerError::ModuleLoadError)?;
     let module_stmts = module.program.stmts.clone();
     let exported_names = module.exported_names.clone();
+    let module_source = module.source.clone();
 
     // 4. Validate that all requested names are exported
     for name in names {
@@ -260,24 +281,15 @@ pub(super) fn compile_selective_import(
     // 6. Generate internal module prefix
     let internal_prefix = format!("__sel_{}", compiler.imported_aliases.len());
 
-    // 7. Mark as compiling (for cycle detection)
-    compiler.compiling_modules.insert(canonical.clone());
-
-    // 8. Save and set module_prefix + base_path for name mangling
-    let old_prefix = compiler.module_prefix.take();
-    let old_base = compiler.base_path.take();
-    compiler.module_prefix = Some(internal_prefix.clone());
-    compiler.base_path = canonical.parent().map(|p| p.to_path_buf());
-
-    // 9. Compile the module's statements
-    for stmt in &module_stmts {
-        compiler.compile_stmt(stmt)?;
-    }
-
-    // 10. Restore prefix and base_path, remove from compiling set
-    compiler.module_prefix = old_prefix;
-    compiler.base_path = old_base;
-    compiler.compiling_modules.remove(&canonical);
+    // 7. Compile the module under its internal namespace while preserving
+    // source context for errors and warnings.
+    compile_module_statements(
+        compiler,
+        &canonical,
+        &module_source,
+        &internal_prefix,
+        &module_stmts,
+    )?;
 
     // 11. Copy only the requested names from mangled globals to user-visible globals
     for name in names {

--- a/akronc/src/statements/imports.rs
+++ b/akronc/src/statements/imports.rs
@@ -34,8 +34,13 @@ fn compile_module_statements(
 
     let old_prefix = compiler.module_prefix.take();
     let old_base = compiler.base_path.take();
+    let old_resolver_module = compiler.resolver_current_module;
     compiler.module_prefix = Some(prefix.to_string());
     compiler.base_path = canonical.parent().map(|path| path.to_path_buf());
+    compiler.resolver_current_module = compiler
+        .resolver_module_by_path
+        .as_ref()
+        .and_then(|modules| modules.get(canonical).copied());
 
     let warning_start = compiler.warnings.len();
     let result = statements
@@ -48,6 +53,7 @@ fn compile_module_statements(
 
     compiler.module_prefix = old_prefix;
     compiler.base_path = old_base;
+    compiler.resolver_current_module = old_resolver_module;
     compiler.compiling_modules.remove(canonical);
 
     result.map_err(|error| CompilerError::ModuleSource {

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -46,7 +46,7 @@ pub struct Cli {
     #[arg(long = "allow-listen", value_name = "IP:PORT", global = true)]
     pub allow_listen: Vec<String>,
 
-    /// Maximum number of live child tasks
+    /// Maximum live child tasks, including explicit spawn and implicit await
     #[arg(long, global = true)]
     pub max_tasks: Option<usize>,
 
@@ -54,7 +54,7 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub max_resources: Option<usize>,
 
-    /// Maximum nesting depth of concurrent task scopes
+    /// Maximum simultaneously live explicit and implicit task scopes
     #[arg(long, global = true)]
     pub max_task_scopes: Option<usize>,
 

--- a/cli/src/commands/circom.rs
+++ b/cli/src/commands/circom.rs
@@ -443,14 +443,20 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
         );
     }
 
-    // Circuit stats profiler
-    if circuit_stats {
+    // Build the backend-independent IR estimate now. The R1CS branch attaches
+    // the exact finalized constraint count after backend optimization.
+    let circuit_stats = if circuit_stats {
         let name = std::path::Path::new(path)
             .file_stem()
             .map(|s| s.to_string_lossy().into_owned());
-        let stats = ir::stats::CircuitStats::from_program(&program, &proven, name.as_deref());
-        eprintln!("{stats}");
-    }
+        Some(ir::stats::CircuitStats::from_program(
+            &program,
+            &proven,
+            name.as_deref(),
+        ))
+    } else {
+        None
+    };
 
     // 6. Backend compilation
     let source_dir = file_path
@@ -461,7 +467,7 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
     match backend {
         "r1cs" => {
             let want_reusable = input_files.len() > 1;
-            let prover = run_r1cs_pipeline(
+            let (prover, final_constraints) = run_r1cs_pipeline(
                 program,
                 r1cs_path,
                 wtns_path,
@@ -477,6 +483,9 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
                 lean_r1cs,
                 key_source,
             )?;
+            if let Some(stats) = circuit_stats {
+                eprintln!("{}", stats.with_final_r1cs_constraints(final_constraints));
+            }
 
             // Extra input files reuse the compiled circuit: only the
             // per-input work runs (hint walk, witness replay, verify,
@@ -518,6 +527,9 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
             Ok(())
         }
         "plonkish" => {
+            if let Some(stats) = circuit_stats {
+                eprintln!("{stats}");
+            }
             let mut memo = artik::ArtikMemo::<F>::new();
             let all_inputs = walk_hints(&mut memo)?;
             run_plonkish_pipeline(

--- a/cli/src/commands/circom.rs
+++ b/cli/src/commands/circom.rs
@@ -445,18 +445,7 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
 
     // Build the backend-independent IR estimate now. The R1CS branch attaches
     // the exact finalized constraint count after backend optimization.
-    let circuit_stats = if circuit_stats {
-        let name = std::path::Path::new(path)
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned());
-        Some(ir::stats::CircuitStats::from_program(
-            &program,
-            &proven,
-            name.as_deref(),
-        ))
-    } else {
-        None
-    };
+    let circuit_stats = super::circuit_stats::collect(circuit_stats, path, &program, &proven);
 
     // 6. Backend compilation
     let source_dir = file_path
@@ -483,9 +472,7 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
                 lean_r1cs,
                 key_source,
             )?;
-            if let Some(stats) = circuit_stats {
-                eprintln!("{}", stats.with_final_r1cs_constraints(final_constraints));
-            }
+            super::circuit_stats::print(circuit_stats, Some(final_constraints));
 
             // Extra input files reuse the compiled circuit: only the
             // per-input work runs (hint walk, witness replay, verify,
@@ -527,9 +514,7 @@ fn circom_command_inner<F: FieldBackend + PoseidonParamsProvider + Groth16Field>
             Ok(())
         }
         "plonkish" => {
-            if let Some(stats) = circuit_stats {
-                eprintln!("{stats}");
-            }
+            super::circuit_stats::print(circuit_stats, None);
             let mut memo = artik::ArtikMemo::<F>::new();
             let all_inputs = walk_hints(&mut memo)?;
             run_plonkish_pipeline(

--- a/cli/src/commands/circom/r1cs.rs
+++ b/cli/src/commands/circom/r1cs.rs
@@ -29,7 +29,7 @@ pub(super) fn run_r1cs_pipeline<F, H>(
     want_reusable: bool,
     release_optimized_program: bool,
     key_source: &proving::groth16::ProvingKeySource,
-) -> Result<Option<ReusableProver<F>>>
+) -> Result<(Option<ReusableProver<F>>, usize)>
 where
     F: FieldBackend + PoseidonParamsProvider + Groth16Field,
     H: FnOnce(&mut artik::ArtikMemo<F>) -> Result<HashMap<String, FieldElement<F>>>,
@@ -313,7 +313,11 @@ where
         }
     }
 
-    Ok(generator.map(|generator| ReusableProver::new(cs, prime_id, generator, prepared_key)))
+    let final_constraints = cs.num_constraints();
+    Ok((
+        generator.map(|generator| ReusableProver::new(cs, prime_id, generator, prepared_key)),
+        final_constraints,
+    ))
 }
 
 fn path_stem(path: &str) -> &std::path::Path {

--- a/cli/src/commands/circuit/entry.rs
+++ b/cli/src/commands/circuit/entry.rs
@@ -349,41 +349,58 @@ fn circuit_command_inner<F: FieldBackend + PoseidonParamsProvider + Bn254Ops + G
         );
     }
 
-    // Circuit stats profiler
-    if circuit_stats {
+    // Build the backend-independent IR estimate now. The R1CS branch attaches
+    // the exact finalized constraint count after backend optimization.
+    let circuit_stats = if circuit_stats {
         let name = std::path::Path::new(path)
             .file_stem()
             .map(|s| s.to_string_lossy().into_owned());
-        let stats = ir::stats::CircuitStats::from_program(&program, &proven, name.as_deref());
-        eprintln!("{stats}");
-    }
+        Some(ir::stats::CircuitStats::from_program(
+            &program,
+            &proven,
+            name.as_deref(),
+        ))
+    } else {
+        None
+    };
 
     match backend {
-        "r1cs" => run_r1cs_pipeline(
-            &program,
-            r1cs_path,
-            wtns_path,
-            resolved_inputs.as_ref(),
-            prime_id,
-            prove,
-            solidity_path,
-            &style,
-            verbose,
-            no_optimize,
-            &proven,
-            key_source,
-        ),
-        "plonkish" => run_plonkish_pipeline(
-            &program,
-            resolved_inputs.as_ref(),
-            prove,
-            plonkish_json_path,
-            &source_dir,
-            &style,
-            verbose,
-            &proven,
-            key_source,
-        ),
+        "r1cs" => {
+            let final_constraints = run_r1cs_pipeline(
+                &program,
+                r1cs_path,
+                wtns_path,
+                resolved_inputs.as_ref(),
+                prime_id,
+                prove,
+                solidity_path,
+                &style,
+                verbose,
+                no_optimize,
+                &proven,
+                key_source,
+            )?;
+            if let Some(stats) = circuit_stats {
+                eprintln!("{}", stats.with_final_r1cs_constraints(final_constraints));
+            }
+            Ok(())
+        }
+        "plonkish" => {
+            if let Some(stats) = circuit_stats {
+                eprintln!("{stats}");
+            }
+            run_plonkish_pipeline(
+                &program,
+                resolved_inputs.as_ref(),
+                prove,
+                plonkish_json_path,
+                &source_dir,
+                &style,
+                verbose,
+                &proven,
+                key_source,
+            )
+        }
         // Unreachable: backend validated at the top of this function
         _ => unreachable!(),
     }

--- a/cli/src/commands/circuit/entry.rs
+++ b/cli/src/commands/circuit/entry.rs
@@ -351,18 +351,8 @@ fn circuit_command_inner<F: FieldBackend + PoseidonParamsProvider + Bn254Ops + G
 
     // Build the backend-independent IR estimate now. The R1CS branch attaches
     // the exact finalized constraint count after backend optimization.
-    let circuit_stats = if circuit_stats {
-        let name = std::path::Path::new(path)
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned());
-        Some(ir::stats::CircuitStats::from_program(
-            &program,
-            &proven,
-            name.as_deref(),
-        ))
-    } else {
-        None
-    };
+    let circuit_stats =
+        super::super::circuit_stats::collect(circuit_stats, path, &program, &proven);
 
     match backend {
         "r1cs" => {
@@ -380,15 +370,11 @@ fn circuit_command_inner<F: FieldBackend + PoseidonParamsProvider + Bn254Ops + G
                 &proven,
                 key_source,
             )?;
-            if let Some(stats) = circuit_stats {
-                eprintln!("{}", stats.with_final_r1cs_constraints(final_constraints));
-            }
+            super::super::circuit_stats::print(circuit_stats, Some(final_constraints));
             Ok(())
         }
         "plonkish" => {
-            if let Some(stats) = circuit_stats {
-                eprintln!("{stats}");
-            }
+            super::super::circuit_stats::print(circuit_stats, None);
             run_plonkish_pipeline(
                 &program,
                 resolved_inputs.as_ref(),

--- a/cli/src/commands/circuit/r1cs.rs
+++ b/cli/src/commands/circuit/r1cs.rs
@@ -28,7 +28,7 @@ pub(super) fn run_r1cs_pipeline<
     no_optimize: bool,
     proven: &std::collections::HashSet<ir::SsaVar>,
     key_source: &proving::groth16::ProvingKeySource,
-) -> Result<()> {
+) -> Result<usize> {
     let mut compiler = R1CSCompiler::<F>::new();
     compiler.prime_id = prime_id;
     compiler.set_proven_boolean(proven.clone());
@@ -305,5 +305,5 @@ pub(super) fn run_r1cs_pipeline<
         }
     }
 
-    Ok(())
+    Ok(compiler.cs.num_constraints())
 }

--- a/cli/src/commands/circuit_stats.rs
+++ b/cli/src/commands/circuit_stats.rs
@@ -1,0 +1,30 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use ir::stats::CircuitStats;
+use ir::{IrProgram, SsaVar};
+use memory::FieldBackend;
+
+pub(super) fn collect<F: FieldBackend>(
+    enabled: bool,
+    path: &str,
+    program: &IrProgram<F>,
+    proven: &HashSet<SsaVar>,
+) -> Option<CircuitStats> {
+    enabled.then(|| {
+        let name = Path::new(path)
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned());
+        CircuitStats::from_program(program, proven, name.as_deref())
+    })
+}
+
+pub(super) fn print(stats: Option<CircuitStats>, final_r1cs_constraints: Option<usize>) {
+    if let Some(stats) = stats {
+        let stats = match final_r1cs_constraints {
+            Some(constraints) => stats.with_final_r1cs_constraints(constraints),
+            None => stats,
+        };
+        eprintln!("{stats}");
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -45,15 +45,21 @@ pub fn print_warnings(compiler: &mut Compiler, source: &str, fmt: ErrorFormat) {
     if warnings.is_empty() {
         return;
     }
-    for w in &warnings {
-        emit_diagnostic(w, source, fmt);
+    for warning in &warnings {
+        let diagnostic_source = warning
+            .primary_span
+            .file
+            .as_deref()
+            .and_then(|path| compiler.module_source(path))
+            .unwrap_or(source);
+        emit_diagnostic(warning, diagnostic_source, fmt);
     }
 }
 
 /// Convert a CompilerError to a rendered diagnostic string.
 pub fn render_compile_error(err: &CompilerError, source: &str, fmt: ErrorFormat) -> String {
     let diag = err.to_diagnostic();
-    render_diagnostic(&diag, source, fmt)
+    render_diagnostic(&diag, err.diagnostic_source().unwrap_or(source), fmt)
 }
 
 /// Render a single diagnostic to a string in the requested format.

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod aot;
 pub mod circom;
 pub mod circuit;
+mod circuit_stats;
 pub mod compile;
 pub mod disassemble;
 pub mod engine;

--- a/cli/src/prove_handler.rs
+++ b/cli/src/prove_handler.rs
@@ -114,11 +114,27 @@ impl DefaultProveHandler {
             eprintln!("{s}");
         }
         if stats.len() > 1 {
-            let total: usize = stats.iter().map(|s| s.total_constraints).sum();
+            let all_final = stats
+                .iter()
+                .all(|stats| stats.final_r1cs_constraints.is_some());
+            let total: usize = stats
+                .iter()
+                .map(|stats| {
+                    stats
+                        .final_r1cs_constraints
+                        .unwrap_or(stats.total_constraints)
+                })
+                .sum();
+            let label = if all_final {
+                "final proving constraints"
+            } else {
+                "pre-optimization estimated constraints"
+            };
             eprintln!(
-                "  Total across {} circuits: {} constraints",
+                "  Total across {} circuits: {} {}",
                 stats.len(),
-                total
+                total,
+                label,
             );
         }
     }

--- a/cli/tests/module_diagnostics_test.rs
+++ b/cli/tests/module_diagnostics_test.rs
@@ -1,0 +1,161 @@
+use std::path::{Path, PathBuf};
+
+use akronc::CompileOptions;
+use cli::commands::ErrorFormat;
+use memory::field::PrimeId;
+
+struct ModuleProject {
+    _directory: tempfile::TempDir,
+    main: PathBuf,
+    module: PathBuf,
+}
+
+fn module_project(module_source: &str) -> ModuleProject {
+    let directory = tempfile::tempdir().unwrap();
+    let main = directory.path().join("main.ach");
+    let module = directory.path().join("broken.ach");
+    std::fs::write(
+        &main,
+        "import \"./broken.ach\" as broken\nprint(broken::answer(1))\n",
+    )
+    .unwrap();
+    std::fs::write(&module, module_source).unwrap();
+    ModuleProject {
+        _directory: directory,
+        main,
+        module,
+    }
+}
+
+fn compile_error(project: &ModuleProject, format: ErrorFormat) -> String {
+    let result = cli::commands::compile::compile_file(
+        project.main.to_str().unwrap(),
+        None,
+        PrimeId::Bn254,
+        format,
+    );
+    format!("{}", result.expect_err("module must fail to compile"))
+}
+
+#[test]
+fn module_parse_error_preserves_file_and_span_in_json() {
+    let project = module_project(
+        "// The parse error is deliberately on line 2.\n\
+         export fn answer(value, ) { value }\n",
+    );
+
+    let rendered = compile_error(&project, ErrorFormat::Json);
+    let diagnostic: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+    let primary = &diagnostic["spans"][0];
+
+    assert_eq!(
+        primary["file_name"],
+        project.module.canonicalize().unwrap().display().to_string()
+    );
+    assert_eq!(primary["line_start"], 2);
+    assert!(diagnostic["message"]
+        .as_str()
+        .unwrap()
+        .contains("expected identifier"));
+}
+
+#[test]
+fn module_parse_error_renders_the_module_source() {
+    let project = module_project(
+        "// The parse error is deliberately on line 2.\n\
+         export fn answer(value, ) { value }\n",
+    );
+
+    let rendered = compile_error(&project, ErrorFormat::Human);
+
+    assert!(rendered.contains(project.module.canonicalize().unwrap().to_str().unwrap()));
+    assert!(rendered.contains("export fn answer(value, ) { value }"));
+    assert!(!rendered.contains("print(broken::answer(1))"));
+}
+
+#[test]
+fn warning_from_imported_module_preserves_its_file() {
+    let project = module_project("export fn answer(unused) { 42 }\n");
+    let source = std::fs::read_to_string(&project.main).unwrap();
+    let mut compiler = cli::commands::new_compiler();
+
+    compiler
+        .compile_program(&source, &CompileOptions::for_source(&project.main))
+        .unwrap();
+
+    let warning = compiler
+        .take_warnings()
+        .into_iter()
+        .find(|warning| {
+            warning
+                .message
+                .contains("unused function parameter: `unused`")
+        })
+        .expect("imported module must emit W001");
+    assert_eq!(
+        warning.primary_span.file.as_deref(),
+        Some(project.module.canonicalize().unwrap().as_path())
+    );
+    assert_eq!(warning.primary_span.line_start, 1);
+}
+
+#[test]
+fn module_path_is_absolute_in_short_diagnostics() {
+    let project = module_project("export fn answer(value, ) { value }\n");
+
+    let rendered = compile_error(&project, ErrorFormat::Short);
+
+    assert!(rendered.starts_with(&project.module.canonicalize().unwrap().display().to_string()));
+    assert!(Path::new(rendered.split(':').next().unwrap()).is_absolute());
+}
+
+#[test]
+fn imported_prove_array_parameters_count_as_reads() {
+    let directory = tempfile::tempdir().unwrap();
+    let main = directory.path().join("main.ach");
+    let module = directory.path().join("proofs.ach");
+    std::fs::write(
+        &main,
+        "import \"./proofs.ach\" as proofs\n\
+         let generated = proofs::prove_membership(\n\
+             0p1,\n\
+             0p2,\n\
+             [0p3, 0p4],\n\
+             [0p0, 0p1]\n\
+         )\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &module,
+        "export fn prove_membership(\n\
+             root,\n\
+             leaf,\n\
+             path: Field[2],\n\
+             indices: Field[2]\n\
+         ) {\n\
+             prove(root: Public) {\n\
+                 merkle_verify(root, leaf, path, indices)\n\
+             }\n\
+         }\n",
+    )
+    .unwrap();
+    let source = std::fs::read_to_string(&main).unwrap();
+    let mut compiler = cli::commands::new_compiler();
+
+    compiler
+        .compile_program(&source, &CompileOptions::for_source(&main))
+        .unwrap();
+
+    let warnings = compiler.take_warnings();
+    assert!(
+        !warnings.iter().any(|warning| {
+            warning
+                .message
+                .contains("unused function parameter: `path`")
+                || warning
+                    .message
+                    .contains("unused function parameter: `indices`")
+        }),
+        "imported prove captures must count as parameter reads: {warnings:?}"
+    );
+}

--- a/cli/tests/module_diagnostics_test.rs
+++ b/cli/tests/module_diagnostics_test.rs
@@ -159,3 +159,57 @@ fn imported_prove_array_parameters_count_as_reads() {
         "imported prove captures must count as parameter reads: {warnings:?}"
     );
 }
+
+#[test]
+fn selectively_imported_prove_uses_its_module_resolver_context() {
+    let directory = tempfile::tempdir().unwrap();
+    let main = directory.path().join("main.ach");
+    let module = directory.path().join("proofs.ach");
+    std::fs::write(
+        &main,
+        // Both builtin callees deliberately receive ExprId(1) in their own
+        // module. The imported merkle call must not resolve as root poseidon.
+        "import { prove_membership } from \"./proofs.ach\"\n\
+         let padding = poseidon(0p1, 0p2)\n\
+         let generated = prove_membership(\n\
+             0p1,\n\
+             0p2,\n\
+             [0p3, 0p4],\n\
+             [0p0, 0p1]\n\
+         )\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &module,
+        "export fn prove_membership(\n\
+             root,\n\
+             leaf,\n\
+             path: Field[2],\n\
+             indices: Field[2]\n\
+         ) {\n\
+             prove(root: Public) {\n\
+                 merkle_verify(root, leaf, path, indices)\n\
+             }\n\
+         }\n",
+    )
+    .unwrap();
+    let source = std::fs::read_to_string(&main).unwrap();
+    let mut compiler = cli::commands::new_compiler();
+
+    compiler
+        .compile_program(&source, &CompileOptions::for_source(&main))
+        .unwrap();
+
+    let warnings = compiler.take_warnings();
+    assert!(
+        !warnings.iter().any(|warning| {
+            warning
+                .message
+                .contains("unused function parameter: `path`")
+                || warning
+                    .message
+                    .contains("unused function parameter: `indices`")
+        }),
+        "selectively imported prove captures must count as parameter reads: {warnings:?}"
+    );
+}

--- a/cli/tests/release_version_contract.rs
+++ b/cli/tests/release_version_contract.rs
@@ -1,8 +1,8 @@
 #[test]
-fn release_version_is_0_1_0_without_a_prerelease_suffix() {
+fn release_version_is_0_1_1_without_a_prerelease_suffix() {
     let version = env!("CARGO_PKG_VERSION");
 
-    assert_eq!(version, "0.1.0");
+    assert_eq!(version, "0.1.1");
     assert_eq!(version.split('.').count(), 3);
     assert!(version.split('.').all(|part| part.parse::<u64>().is_ok()));
 }

--- a/cli/tests/tilino_lab_test.rs
+++ b/cli/tests/tilino_lab_test.rs
@@ -1,0 +1,26 @@
+#[cfg(unix)]
+#[test]
+fn modular_private_auction_passes_the_full_engine_contract() {
+    let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap();
+    let contract = workspace.join("test/projects/tilino-lab/test.sh");
+    assert!(
+        contract.is_file(),
+        "tilino-lab contract is missing: {}",
+        contract.display()
+    );
+
+    let output = std::process::Command::new("bash")
+        .arg(&contract)
+        .env("ACH_BIN", env!("CARGO_BIN_EXE_ach"))
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "tilino-lab failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/diagnostics/src/diagnostic.rs
+++ b/diagnostics/src/diagnostic.rs
@@ -204,6 +204,27 @@ impl Diagnostic {
         }
     }
 
+    /// Attach a source file to every span that does not already name one.
+    ///
+    /// Nested compilation phases can preserve a more specific file by setting
+    /// it first; outer module contexts only fill the remaining gaps.
+    pub fn with_file(mut self, file: PathBuf) -> Self {
+        if self.primary_span.file.is_none() {
+            self.primary_span.file = Some(file.clone());
+        }
+        for label in &mut self.labels {
+            if label.span.file.is_none() {
+                label.span.file = Some(file.clone());
+            }
+        }
+        for suggestion in &mut self.suggestions {
+            if suggestion.span.file.is_none() {
+                suggestion.span.file = Some(file.clone());
+            }
+        }
+        self
+    }
+
     pub fn with_code(mut self, code: impl Into<String>) -> Self {
         self.code = Some(code.into());
         self

--- a/docs/migration/0.1.0.md
+++ b/docs/migration/0.1.0.md
@@ -129,6 +129,12 @@ The same names are global CLI flags with hyphens. Capacity exhaustion is now a
 recoverable error. Use bounded channels for backpressure and `bounded_server`
 or `permit_pool` to cap active handlers.
 
+`max_tasks` counts every live child task, whether created by explicit `spawn`
+or by `await function_call(...)`; it does not count the root task.
+`max_task_scopes` counts all simultaneously live structured scopes across the
+VM, including explicit `concurrent` and implicit single-child `await` scopes.
+It is not a nesting-depth limit.
+
 Task handles are scope-bound and single-use. Replace any design that expects a
 detached task with a lexical `concurrent` scope. Transfer an owned file,
 listener, or connection to a spawned child only when the parent will no longer

--- a/docs/reference/language-0.1.0.md
+++ b/docs/reference/language-0.1.0.md
@@ -145,9 +145,12 @@ the program. Add `--error-format json` for stable machine-readable output.
 
 Every VM has finite bounds. The CLI and `[vm]` configuration expose:
 
-- `max_tasks`
+- `max_tasks`: live child tasks across explicit `spawn` and the implicit child
+  created by `await function_call(...)`; the root task is not counted.
 - `max_resources`
-- `max_task_scopes`
+- `max_task_scopes`: simultaneously live structured task scopes across the
+  VM, including explicit `concurrent` scopes and implicit single-child `await`
+  scopes. This is a global live count, not a nesting-depth limit.
 - `max_pending_native_requests`
 - `max_retained_task_results`
 - `max_channels`
@@ -161,9 +164,9 @@ exhaustion is a recoverable runtime error; it does not silently grow a queue.
 
 | Runtime dimension | Default and hard maximum |
 | --- | ---: |
-| Live child tasks | 65,535 |
+| Live child tasks, explicit and implicit | 65,535 |
 | Open owned resources | 65,535 |
-| Nested task scopes | 1,024 |
+| Simultaneously live task scopes | 1,024 |
 | Pending native requests | 4,096 |
 | Retained task results | 4,096 |
 | Open channels | 4,096 |

--- a/ir-forge/src/ast_lower/mod.rs
+++ b/ir-forge/src/ast_lower/mod.rs
@@ -130,7 +130,11 @@ pub struct OuterResolverState {
     pub table: std::sync::Arc<SymbolTable>,
     /// Annotation map keyed by `(module_id, expr_id)`.
     pub resolved: std::sync::Arc<ResolvedProgram>,
-    /// Root module id in the graph the annotations were built for.
+    /// Module id that contains the prove block being compiled.
+    ///
+    /// This is the graph root for top-level and standalone blocks, but an
+    /// imported function's owning module for a block nested in that function.
+    /// The historical field name is retained for API compatibility.
     pub root_module: ModuleId,
     /// Precomputed map from [`SymbolId`] to the fn_table key the
     /// ProveIR compiler uses. Built once by walking the resolver's
@@ -268,9 +272,9 @@ pub struct ProveIrCompiler<F: FieldBackend = Bn254Fr> {
     /// `compiler` crate's [`Compiler::resolved_program`] doc for
     /// the key semantics.
     resolver_resolved: Option<std::sync::Arc<ResolvedProgram>>,
-    /// The [`ModuleId`] annotations are currently being resolved
-    /// against when the stack is empty. Installed from
-    /// `OuterScope::resolver_state.root_module` at compile-start.
+    /// The [`ModuleId`] annotations are currently being resolved against when
+    /// the stack is empty. Installed from the prove block's entry module at
+    /// compile-start.
     resolver_root_module: Option<ModuleId>,
     /// Stack of module ids that override [`resolver_root_module`]
     /// while walking inlined user-fn bodies. Every

--- a/ir-forge/src/ast_lower/stmts/imports.rs
+++ b/ir-forge/src/ast_lower/stmts/imports.rs
@@ -80,13 +80,14 @@ impl<F: FieldBackend> ProveIrCompiler<F> {
         let module = self
             .module_loader
             .load(&canonical)
-            .map_err(ProveIrError::ModuleLoadError)?;
+            .map_err(|error| ProveIrError::ModuleLoadError(error.to_string()))?;
         // Clone what we need before releasing the borrow on module_loader.
         let exported_names = module.exported_names.clone();
         let stmts = module.program.stmts.clone();
         let exports = crate::module_loader::ModuleExports {
             exported_names,
             program: achronyme_parser::ast::Program { stmts },
+            source: module.source.clone(),
         };
         self.register_module_exports(alias, &exports);
         Ok(())
@@ -107,7 +108,7 @@ impl<F: FieldBackend> ProveIrCompiler<F> {
         let module = self
             .module_loader
             .load(&canonical)
-            .map_err(ProveIrError::ModuleLoadError)?;
+            .map_err(|error| ProveIrError::ModuleLoadError(error.to_string()))?;
         let exported_names = module.exported_names.clone();
         let stmts = module.program.stmts.clone();
 

--- a/ir-forge/src/module_loader.rs
+++ b/ir-forge/src/module_loader.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use achronyme_parser::ast::{Program, Stmt};
+use diagnostics::{Diagnostic, SpanRange};
 
 use crate::suggest::find_similar_ir;
 
@@ -9,6 +11,58 @@ use crate::suggest::find_similar_ir;
 pub struct ModuleExports {
     pub exported_names: Vec<String>,
     pub program: Program,
+    pub source: String,
+}
+
+/// Structured module-loading failure with enough context for source-aware
+/// diagnostics.
+#[derive(Clone, Debug)]
+pub enum ModuleLoadError {
+    Read {
+        path: PathBuf,
+        message: String,
+    },
+    Diagnostic {
+        source: String,
+        diagnostic: Box<Diagnostic>,
+    },
+}
+
+impl ModuleLoadError {
+    pub fn source(&self) -> Option<&str> {
+        match self {
+            Self::Read { .. } => None,
+            Self::Diagnostic { source, .. } => Some(source),
+        }
+    }
+
+    pub fn to_diagnostic(&self) -> Diagnostic {
+        match self {
+            Self::Read { path, message } => Diagnostic::error(
+                message.clone(),
+                SpanRange::point(0, 0, 0).with_file(path.clone()),
+            ),
+            Self::Diagnostic { diagnostic, .. } => *diagnostic.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ModuleLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read { message, .. } => write!(f, "{message}"),
+            Self::Diagnostic { diagnostic, .. } => write!(f, "{}", diagnostic.message),
+        }
+    }
+}
+
+impl std::error::Error for ModuleLoadError {}
+
+fn source_diagnostic(path: &Path, source: String, diagnostic: Diagnostic) -> ModuleLoadError {
+    ModuleLoadError::Diagnostic {
+        source,
+        diagnostic: Box::new(diagnostic.with_file(path.to_path_buf())),
+    }
 }
 
 /// Loads, caches, and deduplicates module files. Detects circular imports.
@@ -32,27 +86,32 @@ impl ModuleLoader {
     /// Load a module from the given canonical path.
     /// Returns the exported names and the parsed AST.
     /// Caches results for deduplication.
-    pub fn load(&mut self, canonical_path: &Path) -> Result<&ModuleExports, String> {
+    pub fn load(&mut self, canonical_path: &Path) -> Result<&ModuleExports, ModuleLoadError> {
         if self.cache.contains_key(canonical_path) {
             return Ok(&self.cache[canonical_path]);
         }
 
-        let source = std::fs::read_to_string(canonical_path)
-            .map_err(|e| format!("cannot read {}: {}", canonical_path.display(), e))?;
+        let source =
+            std::fs::read_to_string(canonical_path).map_err(|error| ModuleLoadError::Read {
+                path: canonical_path.to_path_buf(),
+                message: format!("cannot read {}: {error}", canonical_path.display()),
+            })?;
 
         let (program, parse_errors) = achronyme_parser::parse_program(&source);
         if let Some(err) = parse_errors
             .iter()
             .find(|d| d.severity == diagnostics::Severity::Error)
         {
-            return Err(format!(
-                "parse error in {}: {}",
-                canonical_path.display(),
-                err.message
-            ));
+            return Err(source_diagnostic(canonical_path, source, err.clone()));
         }
 
-        let exported_names = collect_exports(&program)?;
+        let exported_names = collect_exports(&program).map_err(|message| {
+            source_diagnostic(
+                canonical_path,
+                source.clone(),
+                Diagnostic::error(message, SpanRange::point(1, 1, 0)),
+            )
+        })?;
 
         let key = canonical_path.to_path_buf();
         self.cache.insert(
@@ -60,10 +119,18 @@ impl ModuleLoader {
             ModuleExports {
                 exported_names,
                 program,
+                source,
             },
         );
 
         Ok(&self.cache[&key])
+    }
+
+    /// Return cached source text for a successfully loaded canonical module.
+    pub fn source(&self, canonical_path: &Path) -> Option<&str> {
+        self.cache
+            .get(canonical_path)
+            .map(|module| module.source.as_str())
     }
 }
 

--- a/ir-forge/src/resolver_adapter.rs
+++ b/ir-forge/src/resolver_adapter.rs
@@ -157,7 +157,10 @@ impl<'a> ModuleSource for ModuleLoaderSource<'a> {
                 });
             }
         }
-        let exports = self.loader.load(canonical)?;
+        let exports = self
+            .loader
+            .load(canonical)
+            .map_err(|error| error.to_string())?;
         Ok(LoadedModule {
             program: exports.program.clone(),
             exported_names: exports.exported_names.clone(),

--- a/ir/src/stats/circuit.rs
+++ b/ir/src/stats/circuit.rs
@@ -29,8 +29,13 @@ pub struct CircuitStats {
     pub n_witness: usize,
     /// Total IR instructions (excluding Const/Input).
     pub n_instructions: usize,
-    /// Total estimated R1CS constraints.
+    /// Pre-optimization R1CS constraint estimate derived from optimized IR.
     pub total_constraints: usize,
+    /// Exact constraint count in the finalized R1CS used for proving.
+    ///
+    /// This is `None` until an R1CS backend has emitted and finalized the
+    /// constraint system. Non-R1CS backends leave it unset.
+    pub final_r1cs_constraints: Option<usize>,
 }
 
 impl CircuitStats {
@@ -218,7 +223,14 @@ impl CircuitStats {
             n_witness,
             n_instructions,
             total_constraints,
+            final_r1cs_constraints: None,
         }
+    }
+
+    /// Attach the exact constraint count from the finalized proving R1CS.
+    pub fn with_final_r1cs_constraints(mut self, constraints: usize) -> Self {
+        self.final_r1cs_constraints = Some(constraints);
+        self
     }
 
     /// Returns the category with the highest constraint cost, if any.

--- a/ir/src/stats/display.rs
+++ b/ir/src/stats/display.rs
@@ -12,11 +12,24 @@ impl fmt::Display for CircuitStats {
             "  Inputs:  {} public, {} witness",
             self.n_public, self.n_witness
         )?;
+        writeln!(
+            f,
+            "  PRE-OPTIMIZATION ESTIMATE: {} constraints",
+            self.total_constraints
+        )?;
+        match self.final_r1cs_constraints {
+            Some(constraints) => {
+                writeln!(f, "  FINAL PROVING CONSTRAINTS: {constraints}")?;
+            }
+            None => {
+                writeln!(f, "  FINAL PROVING CONSTRAINTS: unavailable")?;
+            }
+        }
         writeln!(f, "  {bar}")?;
         writeln!(
             f,
             "  {:<20} {:>6}  {:>11}  {:>5}",
-            "Category", "Instrs", "Constraints", "%"
+            "Category", "Instrs", "Est. constraints", "%"
         )?;
         writeln!(f, "  {bar}")?;
 
@@ -48,7 +61,7 @@ impl fmt::Display for CircuitStats {
         writeln!(
             f,
             "  {:<20} {:>6}  {:>11}",
-            "TOTAL", self.n_instructions, self.total_constraints
+            "ESTIMATE TOTAL", self.n_instructions, self.total_constraints
         )?;
 
         if let Some(top) = self.bottleneck() {

--- a/ir/src/stats/tests/behavior.rs
+++ b/ir/src/stats/tests/behavior.rs
@@ -238,13 +238,16 @@ fn display_format() {
         rhs: v1,
     });
 
-    let stats = CircuitStats::from_program(&prog, &empty_proven(), Some("test_circuit"));
+    let stats = CircuitStats::from_program(&prog, &empty_proven(), Some("test_circuit"))
+        .with_final_r1cs_constraints(0);
     let output = format!("{stats}");
     assert!(output.contains("test_circuit"));
     assert!(output.contains("1 public"));
     assert!(output.contains("1 witness"));
     assert!(output.contains("Arithmetic"));
-    assert!(output.contains("TOTAL"));
+    assert!(output.contains("PRE-OPTIMIZATION ESTIMATE"));
+    assert!(output.contains("FINAL PROVING CONSTRAINTS"));
+    assert_eq!(stats.final_r1cs_constraints, Some(0));
 }
 
 #[test]

--- a/prove-engine/src/execute.rs
+++ b/prove-engine/src/execute.rs
@@ -41,13 +41,17 @@ impl ProveHandler for ProveEngine {
             program
         };
 
-        // 3b. Collect circuit stats if enabled
-        if self.opts.circuit_stats {
+        // 3b. Build the pre-optimization estimate if enabled. The R1CS path
+        // attaches its exact finalized count before publishing the stats.
+        let circuit_stats = if self.opts.circuit_stats {
             let proven = ir::passes::bool_prop::compute_proven_boolean(&program);
             let name = prove_ir.name.as_deref();
-            let stats = ir::stats::CircuitStats::from_program(&program, &proven, name);
-            self.observer.on_circuit_stats(stats);
-        }
+            Some(ir::stats::CircuitStats::from_program(
+                &program, &proven, name,
+            ))
+        } else {
+            None
+        };
 
         // 4. Build input map from scope_values (public + witness + capture names).
         //    Validate that all required values are present.
@@ -116,8 +120,11 @@ impl ProveHandler for ProveEngine {
         //     compiler reads the full input map up front, so its walk stays
         //     here.
         match self.opts.backend {
-            ProveBackend::R1cs => self.prove_r1cs(program, &prove_ir, inputs),
+            ProveBackend::R1cs => self.prove_r1cs(program, &prove_ir, inputs, circuit_stats),
             ProveBackend::Plonkish => {
+                if let Some(stats) = circuit_stats {
+                    self.observer.on_circuit_stats(stats);
+                }
                 let mut artik_memo = artik::ArtikMemo::<memory::Bn254Fr>::new();
                 walk_circom_hints(&prove_ir, &mut inputs, &mut artik_memo)?;
                 self.prove_plonkish(&program, &inputs)

--- a/prove-engine/src/r1cs.rs
+++ b/prove-engine/src/r1cs.rs
@@ -13,6 +13,7 @@ impl ProveEngine {
         program: ir::IrProgram,
         prove_ir: &ir_forge::ProveIR,
         mut inputs: HashMap<String, FieldElement>,
+        circuit_stats: Option<ir::stats::CircuitStats>,
     ) -> Result<ProveResult, ProveError> {
         // Prover constructor: identical constraint surface, but skips the
         // per-constraint origin log — this path never reads origins (they
@@ -72,6 +73,10 @@ impl ProveEngine {
             .map_err(|e| ProveError::Verification(format!("{e}")))?;
 
         let n_constraints = r1cs.cs.num_constraints();
+        if let Some(stats) = circuit_stats {
+            self.observer
+                .on_circuit_stats(stats.with_final_r1cs_constraints(n_constraints));
+        }
         // Proof generation needs only the constraint system and the witness;
         // drop the rest of the compile working set before the SNARK setup.
         let cs = r1cs.into_constraint_system();

--- a/test/projects/tilino-lab/README.md
+++ b/test/projects/tilino-lab/README.md
@@ -1,0 +1,55 @@
+# Tilino Lab: Private Concurrent Auction
+
+Tilino Lab is Achronyme's versioned end-to-end maturity fixture. It combines
+namespace modules, typed array captures across a module boundary, structured
+concurrency, bounded channels, owned TCP and file resources, explicit host
+capabilities, Poseidon commitments, Merkle membership, and a Groth16 winner
+proof in one program.
+
+## Module layout
+
+```text
+src/main.ach       application orchestration
+src/transport.ach  TCP clients, bounded channel, deadline, and task outcomes
+src/auction.ach    commitments, winner proof, and public receipt formatting
+src/registry.ach   bidder leaves, Merkle root, path, and direction indices
+src/artifacts.ach  concurrent artifact writes and receipt read-back
+```
+
+`src/main.ach` remains a thin orchestrator. Internal network and file helpers
+remain private to their modules. The `Field[2]` Merkle path and index arrays
+cross from `registry.ach` through `main.ach` into a `prove` block in
+`auction.ach`, locking the multi-module capture contract.
+
+## Security boundary
+
+The fixture uses `--insecure-dev-setup`. Its proving parameters are local and
+development-only. The resulting proof tests language and interoperability
+behavior; it is not a production trusted proof. Production requires a
+ceremony-derived key for the exact optimized circuit.
+
+Only commitments cross the loopback TCP boundary. Bid amounts and nonces stay
+private witness values. The proof exposes the three commitments and the bidder
+registry root.
+
+## Run
+
+```text
+sh scripts/run-demo.sh
+```
+
+The runner grants only its temporary output directory and one exact loopback
+address. Override `TILINO_ADDRESS`, `TILINO_OUTPUT_DIR`, `TILINO_ENGINE`, or
+the three bid variables to exercise alternate cases.
+
+## Contract
+
+```text
+ACH_BIN=/path/to/ach sh test.sh
+```
+
+The contract checks interpreter and LLVM JIT execution, detached verification,
+tampered public-input rejection, capability and proving-authority denial,
+structured-concurrency exhaustion, a false-winner constraint failure, exact
+R1CS statistics, and the standalone AOT capability boundary. All generated
+keys and artifacts live under a temporary directory removed on exit.

--- a/test/projects/tilino-lab/achronyme.toml
+++ b/test/projects/tilino-lab/achronyme.toml
@@ -1,0 +1,18 @@
+[project]
+name = "tilino-lab"
+version = "0.1.1"
+entry = "src/main.ach"
+
+[build]
+backend = "r1cs"
+
+[vm]
+max_tasks = 24
+max_resources = 24
+max_task_scopes = 24
+max_pending_native_requests = 24
+max_retained_task_results = 24
+max_channels = 4
+max_channel_operations = 24
+blocking_workers = 4
+blocking_queue_capacity = 24

--- a/test/projects/tilino-lab/scripts/run-demo.sh
+++ b/test/projects/tilino-lab/scripts/run-demo.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ACH_BIN=${ACH_BIN:-ach}
+ADDRESS=${TILINO_ADDRESS:-127.0.0.1:39417}
+OUTPUT_DIR=${TILINO_OUTPUT_DIR:-$PROJECT_ROOT/build/demo-output}
+ENGINE=${TILINO_ENGINE:-interpreter}
+MAX_TASKS=${TILINO_MAX_TASKS:-24}
+ALICE_BID=${TILINO_ALICE_BID:-500}
+BOB_BID=${TILINO_BOB_BID:-750}
+CHARLIE_BID=${TILINO_CHARLIE_BID:-300}
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR=$(CDPATH= cd -- "$OUTPUT_DIR" && pwd)
+
+(
+    cd "$PROJECT_ROOT"
+    printf '%s\n' \
+        "$ADDRESS" \
+        "$OUTPUT_DIR" \
+        "$ALICE_BID" \
+        "$BOB_BID" \
+        "$CHARLIE_BID" |
+        "$ACH_BIN" \
+            --insecure-dev-setup \
+            --allow-read "$OUTPUT_DIR" \
+            --allow-write "$OUTPUT_DIR" \
+            --allow-connect "$ADDRESS" \
+            --allow-listen "$ADDRESS" \
+            --max-tasks "$MAX_TASKS" \
+            run \
+            --engine "$ENGINE" \
+            --circuit-stats
+)

--- a/test/projects/tilino-lab/src/artifacts.ach
+++ b/test/projects/tilino-lab/src/artifacts.ach
@@ -1,0 +1,43 @@
+// Concurrent proof bundle persistence and receipt read-back validation.
+
+fn write_artifact(path, contents) {
+    let file = await create_file(path)
+    let written = await file_write(file, contents)
+    await file_close(file)
+    assert(written > 0)
+    written
+}
+
+export fn write_bundle(
+    output_dir,
+    proof_document,
+    public_document,
+    vkey_document,
+    receipt_document
+) {
+    let proof_path = output_dir + "/proof.json"
+    let public_path = output_dir + "/public.json"
+    let vkey_path = output_dir + "/verification_key.json"
+    let receipt_path = output_dir + "/receipt.txt"
+
+    let artifact_bytes = concurrent {
+        let proof_task = spawn write_artifact(proof_path, proof_document)
+        let public_task = spawn write_artifact(public_path, public_document)
+        let vkey_task = spawn write_artifact(vkey_path, vkey_document)
+        let receipt_task = spawn write_artifact(receipt_path, receipt_document)
+
+        let proof_bytes = await proof_task
+        let public_bytes = await public_task
+        let vkey_bytes = await vkey_task
+        let receipt_bytes = await receipt_task
+        proof_bytes + public_bytes + vkey_bytes + receipt_bytes
+    }
+
+    let receipt_reader = await open_file(receipt_path)
+    let receipt_bytes = await file_read(receipt_reader, 65536)
+    assert(receipt_bytes != nil)
+    await file_close(receipt_reader)
+    assert(read_file(receipt_path) == receipt_document)
+
+    {"bytes": artifact_bytes, "receipt_path": receipt_path}
+}

--- a/test/projects/tilino-lab/src/auction.ach
+++ b/test/projects/tilino-lab/src/auction.ach
@@ -1,0 +1,61 @@
+// Auction commitments, winner constraints, and public receipt formatting.
+
+export fn alice_nonce() { 0p1111 }
+export fn bob_nonce() { 0p2222 }
+export fn charlie_nonce() { 0p3333 }
+
+export fn commitment(bid, nonce) {
+    poseidon(bid, nonce)
+}
+
+export fn prove_winner(
+    alice_bid,
+    bob_bid,
+    charlie_bid,
+    alice_nonce_value,
+    bob_nonce_value,
+    charlie_nonce_value,
+    commit_alice,
+    commit_bob,
+    commit_charlie,
+    registry_root,
+    bidder_bob,
+    bob_path: Field[2],
+    bob_indices: Field[2]
+) {
+    let proof = prove winner(
+        commit_bob: Public,
+        commit_alice: Public,
+        commit_charlie: Public,
+        registry_root: Public
+    ) {
+        assert_eq(poseidon(bob_bid, bob_nonce_value), commit_bob)
+        assert_eq(poseidon(alice_bid, alice_nonce_value), commit_alice)
+        assert_eq(poseidon(charlie_bid, charlie_nonce_value), commit_charlie)
+
+        range_check(alice_bid, 32)
+        range_check(bob_bid, 32)
+        range_check(charlie_bid, 32)
+        assert(bob_bid > 0p0)
+        assert(bob_bid > alice_bid)
+        assert(bob_bid > charlie_bid)
+
+        merkle_verify(registry_root, bidder_bob, bob_path, bob_indices)
+    }
+    proof
+}
+
+export fn receipt(
+    accepted_commitments,
+    commit_bob,
+    commit_alice,
+    commit_charlie,
+    registry_root
+) {
+    "winner=bob\n" +
+        "accepted_commitments=" + accepted_commitments.to_string() + "\n" +
+        "winner_commitment=" + commit_bob.to_string() + "\n" +
+        "alice_commitment=" + commit_alice.to_string() + "\n" +
+        "charlie_commitment=" + commit_charlie.to_string() + "\n" +
+        "registry_root=" + registry_root.to_string() + "\n"
+}

--- a/test/projects/tilino-lab/src/main.ach
+++ b/test/projects/tilino-lab/src/main.ach
@@ -1,0 +1,78 @@
+// Thin application orchestrator for the private concurrent auction.
+
+import "./transport.ach" as transport
+import "./auction.ach" as auction
+import "./registry.ach" as registry
+import "./artifacts.ach" as artifacts
+
+print("=== Private Concurrent Auction ===")
+print("Enter loopback address, output directory, and three bids.")
+
+let address = read_line()
+let output_dir = read_line()
+let alice_bid = parse_int(read_line()).to_field()
+let bob_bid = parse_int(read_line()).to_field()
+let charlie_bid = parse_int(read_line()).to_field()
+
+assert(alice_bid > 0p0)
+assert(bob_bid > 0p0)
+assert(charlie_bid > 0p0)
+
+let alice_nonce = auction::alice_nonce()
+let bob_nonce = auction::bob_nonce()
+let charlie_nonce = auction::charlie_nonce()
+let commit_alice = auction::commitment(alice_bid, alice_nonce)
+let commit_bob = auction::commitment(bob_bid, bob_nonce)
+let commit_charlie = auction::commitment(charlie_bid, charlie_nonce)
+
+let accepted_commitments = await transport::exchange_commitments(
+    address,
+    commit_alice,
+    commit_bob,
+    commit_charlie,
+)
+print("commitments accepted: " + accepted_commitments.to_string())
+
+let bidder_bob = registry::bob_leaf()
+let registry_root = registry::root()
+let bob_path: Field[2] = registry::bob_path()
+let bob_indices: Field[2] = registry::bob_indices()
+
+let winner_proof = auction::prove_winner(
+    alice_bid,
+    bob_bid,
+    charlie_bid,
+    alice_nonce,
+    bob_nonce,
+    charlie_nonce,
+    commit_alice,
+    commit_bob,
+    commit_charlie,
+    registry_root,
+    bidder_bob,
+    bob_path,
+    bob_indices,
+)
+
+let proof_valid = verify_proof(winner_proof)
+assert(proof_valid)
+print("winner proof verified: " + proof_valid.to_string())
+
+let receipt = auction::receipt(
+    accepted_commitments,
+    commit_bob,
+    commit_alice,
+    commit_charlie,
+    registry_root,
+)
+let bundle = await artifacts::write_bundle(
+    output_dir,
+    proof_json(winner_proof),
+    proof_public(winner_proof),
+    proof_vkey(winner_proof),
+    receipt,
+)
+
+print("artifact bytes written: " + bundle["bytes"].to_string())
+print("receipt: " + bundle["receipt_path"])
+print("PASS: private_concurrent_auction")

--- a/test/projects/tilino-lab/src/registry.ach
+++ b/test/projects/tilino-lab/src/registry.ach
@@ -1,0 +1,23 @@
+// Public four-leaf bidder registry and Bob's fixed membership path.
+
+export fn alice_leaf() { poseidon(0p101, 0p9001) }
+export fn bob_leaf() { poseidon(0p102, 0p9002) }
+export fn charlie_leaf() { poseidon(0p103, 0p9003) }
+export fn reserve_leaf() { poseidon(0p104, 0p9004) }
+
+export fn bob_upper_sibling() {
+    poseidon(charlie_leaf(), reserve_leaf())
+}
+
+export fn bob_path() {
+    [alice_leaf(), bob_upper_sibling()]
+}
+
+export fn bob_indices() {
+    [0p1, 0p0]
+}
+
+export fn root() {
+    let path: Field[2] = bob_path()
+    poseidon(poseidon(path[0], bob_leaf()), path[1])
+}

--- a/test/projects/tilino-lab/src/transport.ach
+++ b/test/projects/tilino-lab/src/transport.ach
@@ -1,0 +1,80 @@
+// Commitment-only transport with bounded structured concurrency.
+
+fn submit_commitment(address, bidder, commitment, delay_ms) {
+    await sleep(delay_ms)
+
+    let connection = await tcp_connect(address)
+    let payload = bidder + ":" + commitment.to_string()
+    let written = await tcp_write(connection, payload)
+    let acknowledgement = await tcp_read(connection, 64)
+    await tcp_close(connection)
+
+    assert(written > 0)
+    assert(acknowledgement != nil)
+    written
+}
+
+fn collect_commitments(listener, events) {
+    for _index in 0..3 {
+        let connection = await tcp_accept(listener)
+        let payload = await tcp_read(connection, 256)
+        assert(payload != nil)
+
+        await channel_send(events, payload)
+        await tcp_write(connection, "accepted")
+        await tcp_close(connection)
+    }
+
+    await tcp_listener_close(listener)
+    3
+}
+
+fn consume_commitments(events) {
+    mut accepted = 0
+    for _index in 0..3 {
+        let payload = await channel_receive(events)
+        assert(payload != nil)
+        accepted = accepted + 1
+        await yield_now()
+    }
+    accepted
+}
+
+export fn exchange_commitments(
+    address,
+    commit_alice,
+    commit_bob,
+    commit_charlie
+) {
+    let listener = await tcp_listen(address)
+    let commitment_events = channel(1)
+
+    let accepted_commitments = concurrent {
+        let server_task = spawn collect_commitments(listener, commitment_events)
+        let consumer_task = spawn consume_commitments(commitment_events)
+        let deadline_task = spawn timeout_after(5000)
+
+        let alice_task = spawn submit_commitment(address, "alice", commit_alice, 1)
+        let bob_task = spawn submit_commitment(address, "bob", commit_bob, 2)
+        let charlie_task = spawn submit_commitment(address, "charlie", commit_charlie, 3)
+
+        let server_race = await [server_task, deadline_task] as race
+        assert(server_race["index"] == 0)
+        assert(server_race["ok"] == true)
+        assert(server_race["value"] == 3)
+
+        let alice_outcome = await alice_task as outcome
+        let bob_outcome = await bob_task as outcome
+        let charlie_outcome = await charlie_task as outcome
+        assert(alice_outcome["ok"] == true)
+        assert(bob_outcome["ok"] == true)
+        assert(charlie_outcome["ok"] == true)
+
+        let consumed = await consumer_task
+        assert(consumed == 3)
+        consumed
+    }
+
+    channel_close(commitment_events)
+    accepted_commitments
+}

--- a/test/projects/tilino-lab/test.sh
+++ b/test/projects/tilino-lab/test.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ACH_BIN=${ACH_BIN:-ach}
+CASE_ROOT=$(mktemp -d /tmp/achronyme-tilino-lab.XXXXXX)
+PORT_BASE=${TILINO_PORT_BASE:-$((30000 + ($$ % 20000)))}
+
+cleanup() {
+    rm -rf -- "$CASE_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+export XDG_CACHE_HOME="$CASE_ROOT/cache"
+
+expect_text() {
+    file=$1
+    text=$2
+    if ! grep -Fq -- "$text" "$file"; then
+        printf 'missing required text in %s: %s\n' "$file" "$text" >&2
+        exit 1
+    fi
+}
+
+expect_failure() {
+    label=$1
+    pattern=$2
+    shift 2
+    stdout_file="$CASE_ROOT/$label.stdout"
+    stderr_file="$CASE_ROOT/$label.stderr"
+
+    if "$@" >"$stdout_file" 2>"$stderr_file"; then
+        printf 'expected failure but command passed: %s\n' "$label" >&2
+        exit 1
+    fi
+    if ! grep -Eqi "$pattern" "$stdout_file" "$stderr_file"; then
+        printf 'failure did not match contract: %s (%s)\n' "$label" "$pattern" >&2
+        sed -n '1,120p' "$stdout_file" >&2
+        sed -n '1,120p' "$stderr_file" >&2
+        exit 1
+    fi
+}
+
+run_demo() {
+    engine=$1
+    port=$2
+    output_dir=$3
+    log=$4
+    TILINO_ADDRESS="127.0.0.1:$port" \
+    TILINO_OUTPUT_DIR="$output_dir" \
+    TILINO_ENGINE="$engine" \
+        sh "$PROJECT_ROOT/scripts/run-demo.sh" >"$log" 2>&1
+}
+
+verify_bundle() {
+    output_dir=$1
+    log=$2
+    "$ACH_BIN" verify \
+        --proof "$output_dir/proof.json" \
+        --public "$output_dir/public.json" \
+        --vkey "$output_dir/verification_key.json" \
+        --curve bn254 \
+        --format json >"$log"
+    grep -Eq '"curve"[[:space:]]*:[[:space:]]*"bn254"' "$log"
+    grep -Eq '"valid"[[:space:]]*:[[:space:]]*true' "$log"
+}
+
+run_without_proving_authority() {
+    output_dir="$CASE_ROOT/no-proving-authority"
+    address="127.0.0.1:$((PORT_BASE + 2))"
+    mkdir -p "$output_dir"
+    (
+        cd "$PROJECT_ROOT"
+        printf '%s\n' "$address" "$output_dir" 500 750 300 |
+            "$ACH_BIN" \
+                --allow-read "$output_dir" \
+                --allow-write "$output_dir" \
+                --allow-connect "$address" \
+                --allow-listen "$address" \
+                run --engine interpreter
+    )
+}
+
+MAIN="$PROJECT_ROOT/src/main.ach"
+AUCTION="$PROJECT_ROOT/src/auction.ach"
+REGISTRY="$PROJECT_ROOT/src/registry.ach"
+expect_text "$MAIN" 'import "./transport.ach" as transport'
+expect_text "$MAIN" 'import "./auction.ach" as auction'
+expect_text "$MAIN" 'import "./registry.ach" as registry'
+expect_text "$MAIN" 'import "./artifacts.ach" as artifacts'
+expect_text "$MAIN" 'await transport::exchange_commitments'
+expect_text "$MAIN" 'auction::prove_winner'
+expect_text "$MAIN" 'await artifacts::write_bundle'
+expect_text "$AUCTION" 'bob_path: Field[2]'
+expect_text "$AUCTION" 'bob_indices: Field[2]'
+expect_text "$AUCTION" 'merkle_verify(registry_root, bidder_bob, bob_path, bob_indices)'
+expect_text "$REGISTRY" 'export fn bob_path()'
+expect_text "$REGISTRY" 'export fn bob_indices()'
+
+for forbidden in 'tcp_listen' 'channel(' 'create_file' 'prove winner' 'merkle_verify'; do
+    if grep -Fq -- "$forbidden" "$MAIN"; then
+        printf 'main.ach owns extracted responsibility: %s\n' "$forbidden" >&2
+        exit 1
+    fi
+done
+
+main_lines=$(wc -l <"$MAIN")
+if [ "$main_lines" -gt 90 ]; then
+    printf 'main.ach is not a thin orchestrator: %s lines\n' "$main_lines" >&2
+    exit 1
+fi
+
+INTERPRETER_OUTPUT="$CASE_ROOT/interpreter"
+JIT_OUTPUT="$CASE_ROOT/jit"
+run_demo interpreter "$PORT_BASE" "$INTERPRETER_OUTPUT" "$CASE_ROOT/interpreter.log"
+expect_text "$CASE_ROOT/interpreter.log" 'commitments accepted: 3'
+expect_text "$CASE_ROOT/interpreter.log" 'winner proof verified: true'
+expect_text "$CASE_ROOT/interpreter.log" 'PRE-OPTIMIZATION ESTIMATE'
+expect_text "$CASE_ROOT/interpreter.log" 'FINAL PROVING CONSTRAINTS'
+expect_text "$CASE_ROOT/interpreter.log" 'PASS: private_concurrent_auction'
+if grep -Eq 'unused function parameter: `(bob_path|bob_indices)`' "$CASE_ROOT/interpreter.log"; then
+    printf 'prove array parameters were reported as unused\n' >&2
+    exit 1
+fi
+
+for artifact in proof.json public.json verification_key.json receipt.txt; do
+    test -s "$INTERPRETER_OUTPUT/$artifact"
+done
+grep -Eq '"protocol"[[:space:]]*:[[:space:]]*"groth16"' \
+    "$INTERPRETER_OUTPUT/verification_key.json"
+grep -Fq 'winner=bob' "$INTERPRETER_OUTPUT/receipt.txt"
+grep -Fq 'accepted_commitments=3' "$INTERPRETER_OUTPUT/receipt.txt"
+if grep -Eq '=(300|500|750|1111|2222|3333)$' "$INTERPRETER_OUTPUT/receipt.txt"; then
+    printf 'receipt leaked a bid or nonce\n' >&2
+    exit 1
+fi
+verify_bundle "$INTERPRETER_OUTPUT" "$CASE_ROOT/interpreter-verify.json"
+
+TAMPERED_PUBLIC="$CASE_ROOT/public-tampered.json"
+sed 's/"[0-9][0-9]*"/"1"/' "$INTERPRETER_OUTPUT/public.json" >"$TAMPERED_PUBLIC"
+if "$ACH_BIN" verify \
+    --proof "$INTERPRETER_OUTPUT/proof.json" \
+    --public "$TAMPERED_PUBLIC" \
+    --vkey "$INTERPRETER_OUTPUT/verification_key.json" \
+    --curve bn254 \
+    --format json >"$CASE_ROOT/tampered-verify.json" 2>"$CASE_ROOT/tampered-verify.stderr"; then
+    printf 'tampered public input unexpectedly verified\n' >&2
+    exit 1
+fi
+grep -Eq '"valid"[[:space:]]*:[[:space:]]*false' "$CASE_ROOT/tampered-verify.json"
+
+run_demo jit "$((PORT_BASE + 1))" "$JIT_OUTPUT" "$CASE_ROOT/jit.log"
+cmp -s "$INTERPRETER_OUTPUT/receipt.txt" "$JIT_OUTPUT/receipt.txt"
+verify_bundle "$JIT_OUTPUT" "$CASE_ROOT/jit-verify.json"
+
+expect_failure \
+    missing-capabilities \
+    'file\.read|file\.write|network\.connect|network\.listen|capability' \
+    sh -c 'cd "$1" && exec "$2" --insecure-dev-setup run --engine interpreter' \
+    sh "$PROJECT_ROOT" "$ACH_BIN"
+
+expect_failure \
+    missing-proving-authority \
+    'proof generation|trusted setup|development setup|key source|insecure-dev-setup|trusted-key-dir' \
+    run_without_proving_authority
+
+expect_failure \
+    bounded-task-limit \
+    'live child task count exceeds 2' \
+    env \
+        TILINO_ADDRESS="127.0.0.1:$((PORT_BASE + 3))" \
+        TILINO_OUTPUT_DIR="$CASE_ROOT/task-limit" \
+        TILINO_MAX_TASKS=2 \
+        sh "$PROJECT_ROOT/scripts/run-demo.sh"
+
+expect_failure \
+    false-winner \
+    'constraint|unsatisfied|assertion failed|circom assert' \
+    env \
+        TILINO_ADDRESS="127.0.0.1:$((PORT_BASE + 4))" \
+        TILINO_OUTPUT_DIR="$CASE_ROOT/false-winner" \
+        TILINO_ALICE_BID=900 \
+        TILINO_BOB_BID=750 \
+        TILINO_CHARLIE_BID=300 \
+        sh "$PROJECT_ROOT/scripts/run-demo.sh"
+
+(
+    cd "$PROJECT_ROOT"
+    "$ACH_BIN" \
+        --insecure-dev-setup \
+        --allow-read "$CASE_ROOT" \
+        --allow-write "$CASE_ROOT" \
+        --allow-connect "127.0.0.1:$((PORT_BASE + 5))" \
+        --allow-listen "127.0.0.1:$((PORT_BASE + 5))" \
+        inspect --manifest >"$CASE_ROOT/manifest.txt"
+)
+expect_text "$CASE_ROOT/manifest.txt" 'effects: task,io.console,io.file,io.network,io.clock,prove,verify,circuit'
+expect_text "$CASE_ROOT/manifest.txt" 'proving-key-source: insecure-local'
+
+DUMMY_RUNTIME="$CASE_ROOT/libakron_aot_runtime.a"
+: >"$DUMMY_RUNTIME"
+expect_failure \
+    aot-capability-boundary \
+    'standalone AOT runtime does not provide required capabilities: PROVE, VERIFY, CIRCOM' \
+    sh -c 'cd "$1" && exec "$2" --insecure-dev-setup aot --runtime "$3" --output "$4"' \
+    sh "$PROJECT_ROOT" "$ACH_BIN" "$DUMMY_RUNTIME" "$CASE_ROOT/tilino-auction"
+
+printf 'tilino-lab-ok\n'

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "achronyme-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/achronyme/achronyme"


### PR DESCRIPTION
## Summary

- preserve canonical module files, spans, and source text across diagnostics
- resolve imported prove blocks in their owning module, including typed array captures
- distinguish IR estimates from finalized R1CS proving constraints
- align max_tasks and max_task_scopes semantics, errors, and documentation
- integrate Tilino Lab as a modular interpreter/JIT/proving/security/AOT contract
- prepare the workspace and WASM package for 0.1.1

## Verification

- cargo build --workspace
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- cargo test --doc --workspace
- bash test/run_tests.sh (182 passed)
- proving workflow contracts and trusted_setup_workflow.sh
- bash test/llvm_production_gate.sh (x86_64)
